### PR TITLE
Implement shared login sessions

### DIFF
--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -444,7 +444,7 @@ bool ChatSession::handlePrivateMessage(const QJsonObject &json) {
 void ChatSession::onSocketError(QAbstractSocket::SocketError err) {
   if (err == QAbstractSocket::RemoteHostClosedError) {
     if (mHelloReceived) {
-      if (mLoginSession->restart()) {
+      if (mLoginSession->restart(mRoom)) {
         mHelloReceived = false;
         qInfo() << "Connection closed by server, trying to reconnect";
         killTimer(mKeepaliveTimerId);

--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -164,15 +164,16 @@ void reportUnhandled(const QString &message) {
 
 namespace Czateria {
 
-ChatSession::ChatSession(LoginSession &login, const AvatarHandler &avatars,
+ChatSession::ChatSession(QSharedPointer<LoginSession> login,
+                         const AvatarHandler &avatars, const Room &room,
                          QObject *parent)
     : QObject(parent), mWebSocket(new QWebSocket(
                            QString(), QWebSocketProtocol::VersionLatest, this)),
-      mNickname(login.nickname()),
+      mNickname(login->nickname()),
       mHost(QString(QLatin1String("wss://%1-proxy-czateria.interia.pl"))
-                .arg(login.room().port)),
+                .arg(room.port)),
       mHelloReceived(false), mUserListModel(new UserListModel(avatars, this)),
-      mLoginSession(login) {
+      mLoginSession(login), mRoom(room) {
   connect(this, &ChatSession::userLeft, mUserListModel,
           &UserListModel::removeUser);
   connect(mWebSocket, &QWebSocket::textMessageReceived, this,
@@ -181,8 +182,7 @@ ChatSession::ChatSession(LoginSession &login, const AvatarHandler &avatars,
                                                   : Qt::AutoConnection);
   void (QWebSocket::*errSig)(QAbstractSocket::SocketError) = &QWebSocket::error;
   connect(mWebSocket, errSig, this, &ChatSession::onSocketError);
-  mLoginSession.setParent(this);
-  connect(&mLoginSession, &LoginSession::loginSuccessful, this,
+  connect(mLoginSession.data(), &LoginSession::loginSuccessful, this,
           &ChatSession::start);
 }
 
@@ -276,7 +276,7 @@ void ChatSession::onTextMessageReceived(const QString &text) {
       return;
     }
     SendTextMessage(mWebSocket,
-                    QString::fromUtf8(loginMsg(mLoginSession.sessionId(),
+                    QString::fromUtf8(loginMsg(mLoginSession->sessionId(),
                                                channel(), mNickname)));
     mHelloReceived = true;
     return;
@@ -327,6 +327,7 @@ void ChatSession::onTextMessageReceived(const QString &text) {
 
   case 200: /* nick assigned : {"code":200,"username":"gość_15929765"} */
     mNickname = obj[QLatin1String("username")].toString();
+    mLoginSession->setNickname(mNickname);
     emit nicknameAssigned(mNickname);
     break;
 
@@ -443,7 +444,7 @@ bool ChatSession::handlePrivateMessage(const QJsonObject &json) {
 void ChatSession::onSocketError(QAbstractSocket::SocketError err) {
   if (err == QAbstractSocket::RemoteHostClosedError) {
     if (mHelloReceived) {
-      if (mLoginSession.restart()) {
+      if (mLoginSession->restart()) {
         mHelloReceived = false;
         qInfo() << "Connection closed by server, trying to reconnect";
         killTimer(mKeepaliveTimerId);

--- a/czatlib/chatsession.h
+++ b/czatlib/chatsession.h
@@ -4,10 +4,12 @@
 #include <QAbstractSocket>
 #include <QHash>
 #include <QObject>
+#include <QSharedPointer>
 #include <QString>
 
 #include "conversationstate.h"
 #include "loginsession.h"
+#include "room.h"
 
 class QImage;
 class QWebSocket;
@@ -23,8 +25,8 @@ class AvatarHandler;
 class ChatSession : public QObject {
   Q_OBJECT
 public:
-  ChatSession(LoginSession &login, const AvatarHandler &avatars,
-              QObject *parent = nullptr);
+  ChatSession(QSharedPointer<LoginSession> login, const AvatarHandler &avatars,
+              const Room &room, QObject *parent = nullptr);
   virtual ~ChatSession() override;
 
   void start();
@@ -45,7 +47,7 @@ public:
   void sendPrivateMessage(const QString &nickname, const QString &message);
   void sendImage(const QString &nickname, const QImage &image);
 
-  const QString &channel() const { return mLoginSession.room().name; }
+  const QString &channel() const { return mRoom.name; }
   const QString &nickname() const { return mNickname; }
   UserListModel *userListModel() const { return mUserListModel; }
 
@@ -80,7 +82,8 @@ private:
   QHash<QString, ConversationState> mCurrentPrivate;
   QHash<QString, QVector<Message>> mPendingPrivateMsgs;
   UserListModel *const mUserListModel;
-  Czateria::LoginSession &mLoginSession;
+  QSharedPointer<Czateria::LoginSession> mLoginSession;
+  const Room mRoom;
 };
 
 } // namespace Czateria

--- a/czatlib/chatsession.h
+++ b/czatlib/chatsession.h
@@ -27,7 +27,7 @@ class ChatSession : public QObject {
 public:
   ChatSession(QSharedPointer<LoginSession> login, const AvatarHandler &avatars,
               const Room &room, QObject *parent = nullptr);
-  virtual ~ChatSession() override;
+  ~ChatSession() override;
 
   void start();
 

--- a/czatlib/loginsession.cpp
+++ b/czatlib/loginsession.cpp
@@ -64,17 +64,16 @@ void LoginSession::login(const Room &room, const QString &nickname,
       postData);
 }
 
-bool LoginSession::restart() {
-  return false;
-#if 0
+bool LoginSession::restart(const Room &room) {
   if (mPassword.isEmpty()) {
     // only registered users can restart seamlessly due to no captcha being
     // needed
     return false;
   }
-  login(mNickname, mPassword);
+  if (!mLoginOngoing) {
+    login(room, mNickname, mPassword);
+  }
   return true;
-#endif
 }
 
 void LoginSession::setCaptchaReply(const Room &room, const QString &reply) {
@@ -92,6 +91,7 @@ void LoginSession::setCaptchaReply(const Room &room, const QString &reply) {
 }
 
 void LoginSession::onReplyReceived(const QByteArray &data) {
+  mLoginOngoing = false;
   qDebug().noquote() << data;
   QJsonParseError err;
   auto json = QJsonDocument::fromJson(data, &err);
@@ -135,6 +135,7 @@ void LoginSession::sendPostData(const QUrl &address,
     postRequest->deleteLater();
     onReplyReceived(content);
   });
+  mLoginOngoing = true;
 }
 
 QUrlQuery LoginSession::getBasicPostData(const Room &room) const {

--- a/czatlib/loginsession.h
+++ b/czatlib/loginsession.h
@@ -5,7 +5,6 @@
 #include <QString>
 
 #include "loginfailreason.h"
-#include "room.h"
 
 class QImage;
 class QNetworkAccessManager;
@@ -13,23 +12,22 @@ class QUrl;
 class QUrlQuery;
 
 namespace Czateria {
-
+struct Room;
 class LoginSession : public QObject {
   Q_OBJECT
 public:
-  LoginSession(QNetworkAccessManager *nam, const Room &room,
-               QObject *parent = nullptr);
+  LoginSession(QNetworkAccessManager *nam, QObject *parent = nullptr);
 
-  void login();
-  void login(const QString &nickname);
-  void login(const QString &nickname, const QString &password);
+  void login(const QString &nickname = QString());
+  void login(const Room &room, const QString &nickname,
+             const QString &password);
   bool restart();
 
-  void setCaptchaReply(const QString &reply);
+  void setCaptchaReply(const Room &room, const QString &reply);
 
   const QString &sessionId() const { return mSessionId; }
   const QString &nickname() const { return mNickname; }
-  const Room &room() const { return mLoginRoom; }
+  void setNickname(const QString &nickname) { mNickname = nickname; }
 
 signals:
   void loginSuccessful();
@@ -43,11 +41,10 @@ private:
   QString mPassword;
   QString mSessionId;
   QString mCaptchaUid;
-  const Room mLoginRoom;
 
   void onReplyReceived(const QByteArray &content);
   void sendPostData(const QUrl &address, const QUrlQuery &postData);
-  QUrlQuery getBasicPostData() const;
+  QUrlQuery getBasicPostData(const Room &room) const;
 };
 
 } // namespace Czateria

--- a/czatlib/loginsession.h
+++ b/czatlib/loginsession.h
@@ -21,7 +21,7 @@ public:
   void login(const QString &nickname = QString());
   void login(const Room &room, const QString &nickname,
              const QString &password);
-  bool restart();
+  bool restart(const Room &room);
 
   void setCaptchaReply(const Room &room, const QString &reply);
 
@@ -41,6 +41,7 @@ private:
   QString mPassword;
   QString mSessionId;
   QString mCaptchaUid;
+  bool mLoginOngoing;
 
   void onReplyReceived(const QByteArray &content);
   void sendPostData(const QUrl &address, const QUrlQuery &postData);

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -96,11 +96,12 @@ QString getImageFilter() {
 }
 } // namespace
 
-MainChatWindow::MainChatWindow(Czateria::LoginSession &login,
+MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
                                Czateria::AvatarHandler &avatars,
+                               const Czateria::Room &room,
                                const AppSettings &settings, MainWindow *mainWin)
     : QMainWindow(nullptr), ui(new Ui::ChatWidget),
-      mChatSession(new Czateria::ChatSession(login, avatars, this)),
+      mChatSession(new Czateria::ChatSession(login, avatars, room, this)),
       mSortProxy(new QSortFilterProxyModel(this)),
       mNicknameCompleter(
           createNicknameCompleter(mChatSession->userListModel(), this)),

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -3,6 +3,7 @@
 
 #include <QHash>
 #include <QMainWindow>
+#include <QSharedPointer>
 
 class QSortFilterProxyModel;
 class QCompleter;
@@ -19,14 +20,16 @@ class LoginSession;
 class ChatSession;
 class Message;
 class AvatarHandler;
+struct Room;
 } // namespace Czateria
 
 class MainChatWindow : public QMainWindow {
   Q_OBJECT
 
 public:
-  explicit MainChatWindow(Czateria::LoginSession &login,
+  explicit MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
                           Czateria::AvatarHandler &avatars,
+                          const Czateria::Room &room,
                           const AppSettings &settings, MainWindow *mainWin);
   ~MainChatWindow();
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -226,7 +226,7 @@ void MainWindow::startLogin(const Czateria::Room &room) {
     disconnect(*conn);
     delete conn;
     blockUi(ui, false);
-    createChatWindow(session, room);
+    createChatWindow(std::move(session), room);
   });
   connect(session.data(), &Czateria::LoginSession::loginFailed, this,
           &MainWindow::onLoginFailed);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -234,9 +234,9 @@ void MainWindow::startLogin(const Czateria::Room &room) {
   connect(session.data(), &Czateria::LoginSession::loginFailed, this,
           &MainWindow::onLoginFailed);
   inspectRadioButtons(
-      ui, [=]() { session->login(); },
-      [=](auto &&nickname) { session->login(nickname); },
-      [=](auto &&nickname, auto &&password) {
+      ui, [&]() { session->login(); },
+      [&](auto &&nickname) { session->login(nickname); },
+      [&](auto &&nickname, auto &&password) {
         session->login(room, nickname, password);
         connect(session.data(), &Czateria::LoginSession::loginSuccessful,
                 [=]() {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -226,6 +226,9 @@ void MainWindow::startLogin(const Czateria::Room &room) {
     disconnect(*conn);
     delete conn;
     blockUi(ui, false);
+    if (ui->nicknameLineEdit->isEnabled()) {
+      ui->nicknameLineEdit->setText(session->nickname());
+    }
     createChatWindow(std::move(session), room);
   });
   connect(session.data(), &Czateria::LoginSession::loginFailed, this,

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -194,7 +194,8 @@ void MainWindow::refreshRoomList() {
 void MainWindow::onLoginFailed(Czateria::LoginFailReason why,
                                const QString &loginData) {
   loginErrorMessageBox(this, ui, why);
-  if (why == Czateria::LoginFailReason::NickRegistered) {
+  if (why == Czateria::LoginFailReason::NickRegistered &&
+      !loginData.isEmpty()) {
     ui->nicknameLineEdit->setText(loginData);
     auto rv =
         QMessageBox::question(this, tr("Use suggested nickname?"),

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -13,6 +13,7 @@
 #include <QMessageBox>
 #include <QRegExpValidator>
 #include <QSettings>
+#include <QSharedPointer>
 #include <QSortFilterProxyModel>
 
 #include <chrono>
@@ -161,8 +162,19 @@ void MainWindow::onChannelDoubleClicked(const QModelIndex &idx) {
                              QObject::tr("Enter your credentials first"));
     return;
   }
-  auto srcIdx = mRoomSortModel->mapToSource(idx);
-  startLogin(mRoomListModel->room(srcIdx.row()));
+  bool newSessionNeeded = true;
+  auto &&room = mRoomListModel->room(mRoomSortModel->mapToSource(idx).row());
+  if (ui->nicknameOnlyRadioButton->isChecked() ||
+      ui->nickAndPassRadioButton->isChecked()) {
+    auto nickname = ui->nicknameLineEdit->text();
+    if (auto session = mCurrentSessions.value(nickname).toStrongRef()) {
+      createChatWindow(session, room);
+      newSessionNeeded = false;
+    }
+  }
+  if (newSessionNeeded) {
+    startLogin(room);
+  }
 }
 
 bool MainWindow::isLoginDataEntered() {
@@ -197,47 +209,38 @@ void MainWindow::onLoginFailed(Czateria::LoginFailReason why,
 }
 
 void MainWindow::startLogin(const Czateria::Room &room) {
-  auto session = new Czateria::LoginSession(mNAM, room);
-  connect(session, &Czateria::LoginSession::captchaRequired,
+  auto session = QSharedPointer<Czateria::LoginSession>::create(mNAM);
+  auto sessionPtr = session.data();
+  connect(sessionPtr, &Czateria::LoginSession::captchaRequired,
           [=](const QImage &image) {
             QApplication::restoreOverrideCursor();
             CaptchaDialog dialog(image, this);
             if (dialog.exec() == QDialog::Accepted) {
-              session->setCaptchaReply(dialog.response());
+              sessionPtr->setCaptchaReply(room, dialog.response());
             } else {
-              session->deleteLater();
               blockUi(ui, false);
             }
           });
   auto conn = new QMetaObject::Connection;
-  *conn = connect(session, &Czateria::LoginSession::loginSuccessful, [=]() {
+  *conn = connect(sessionPtr, &Czateria::LoginSession::loginSuccessful, [=]() {
     disconnect(*conn);
     delete conn;
     blockUi(ui, false);
-    // we keep our own list of this instead of using
-    // parenting due to having these windows as children
-    // of MainWindow causes QApplication::alert not to
-    // work properly.
-    auto win = new MainChatWindow(*session, mAvatarHandler, mAppSettings, this);
-    mChatWindows.push_back(win);
-    connect(win, &QObject::destroyed, [=]() { mChatWindows.removeAll(win); });
-    win->show();
+    createChatWindow(session, room);
   });
-  connect(session, &Czateria::LoginSession::loginFailed,
-          [=](auto why, auto loginData) {
-            session->deleteLater();
-            onLoginFailed(why, loginData);
-          });
+  connect(session.data(), &Czateria::LoginSession::loginFailed, this,
+          &MainWindow::onLoginFailed);
   inspectRadioButtons(
       ui, [=]() { session->login(); },
       [=](auto &&nickname) { session->login(nickname); },
       [=](auto &&nickname, auto &&password) {
-        session->login(nickname, password);
-        connect(session, &Czateria::LoginSession::loginSuccessful, [=]() {
-          if (ui->saveCredentialsCheckBox) {
-            saveLoginData(nickname, password);
-          }
-        });
+        session->login(room, nickname, password);
+        connect(session.data(), &Czateria::LoginSession::loginSuccessful,
+                [=]() {
+                  if (ui->saveCredentialsCheckBox) {
+                    saveLoginData(nickname, password);
+                  }
+                });
       });
   blockUi(ui, true);
 }
@@ -246,6 +249,22 @@ void MainWindow::saveLoginData(const QString &username,
                                const QString &password) {
   mAppSettings.logins[username] = password;
   mSavedLoginsModel.setStringList(mAppSettings.logins.keys());
+}
+
+void MainWindow::createChatWindow(
+    QSharedPointer<Czateria::LoginSession> session,
+    const Czateria::Room &room) {
+  // we keep our own list of this instead of using parenting because
+  // having these windows as children of MainWindow causes
+  // QApplication::alert not to work properly.
+  auto win =
+      new MainChatWindow(session, mAvatarHandler, room, mAppSettings, this);
+  mChatWindows.push_back(win);
+  if (!session->nickname().isEmpty()) {
+    mCurrentSessions[session->nickname()] = session.toWeakRef();
+  }
+  connect(win, &QObject::destroyed, [=]() { mChatWindows.removeAll(win); });
+  win->show();
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *ev) {

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QHash>
 #include <QMainWindow>
 #include <QStringListModel>
+#include <QWeakPointer>
 
 #include <czatlib/avatarhandler.h>
 #include <czatlib/loginfailreason.h>
@@ -21,6 +22,7 @@ class MainWindow;
 
 namespace Czateria {
 class RoomListModel;
+class LoginSession;
 struct Room;
 } // namespace Czateria
 
@@ -44,6 +46,7 @@ private:
   QStringListModel mSavedLoginsModel;
   AppSettings &mAppSettings;
   QList<MainChatWindow *> mChatWindows;
+  QHash<QString, QWeakPointer<Czateria::LoginSession>> mCurrentSessions;
 
   void onChannelDoubleClicked(const QModelIndex &);
   bool isLoginDataEntered();
@@ -51,6 +54,8 @@ private:
   void onLoginFailed(Czateria::LoginFailReason, const QString &);
   void startLogin(const Czateria::Room &);
   void saveLoginData(const QString &, const QString &);
+  void createChatWindow(QSharedPointer<Czateria::LoginSession>,
+                        const Czateria::Room &);
 
   bool eventFilter(QObject *, QEvent *) override;
   void timerEvent(QTimerEvent *) override;


### PR DESCRIPTION
The code currently assumes that one login session can be used by only one chat
session. However, the Czateria website allows to reuse one login session by
logging into multiple channels at the same time without having to do the login
process from scratch : in fact, doing so while trying to establish a new login
session is not even possible due to the request being rejected and receiving a
"nickname already registered" message.

This commit fixes this by sharing a login session for the same nickname across
different chat sessions and reusing the login sessions if possible.

Fixes #30.