### PR TITLE
Fix crashes due to new debug macros

### DIFF
--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -173,9 +173,10 @@ void reportUnhandled(const QString &message) {
 
 #define SendTextMessage(webSocket, json_obj)                                   \
   do {                                                                         \
+    auto json_obj_ = json_obj;                                                 \
     auto message_ = QString::fromUtf8(                                         \
-        QJsonDocument(json_obj).toJson(QJsonDocument::Compact));               \
-    emit_debug_line(json_obj, message_, ">");                                  \
+        QJsonDocument(json_obj_).toJson(QJsonDocument::Compact));              \
+    emit_debug_line(json_obj_, message_, ">");                                 \
     webSocket->sendTextMessage(message_);                                      \
   } while (0)
 } // namespace


### PR DESCRIPTION
Since the token passed to SendTextMessage was actually a function returning an
object in most cases, and the return value of QJsonObject::operator[] was
deduced to be QJsonValueRef, this caused a very well hidden reference to a
temporary variable to be created when trying to access the "user" key in the
QJsonObject.