### PR TITLE
Further fixes for compiling/running with Qt 5.6.3 for Windows XP

### DIFF
--- a/czatlib/captcha.cpp
+++ b/czatlib/captcha.cpp
@@ -1,6 +1,7 @@
 #include "captcha.h"
 
 #include <QDateTime>
+#include <QDebug>
 #include <QImage>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>

--- a/czatlib/loginsession.cpp
+++ b/czatlib/loginsession.cpp
@@ -1,6 +1,7 @@
 #include "loginsession.h"
 
 #include <QDateTime>
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>

--- a/ui/main.cpp
+++ b/ui/main.cpp
@@ -7,11 +7,12 @@
 #include <QStandardPaths>
 
 namespace {
-const QtMessageHandler defaultHandler = qInstallMessageHandler(nullptr);
-const bool enableDebugOutput = qEnvironmentVariableIsSet("CZATERIA_DEBUG");
+QtMessageHandler defaultHandler;
 
 void msgOutput(QtMsgType type, const QMessageLogContext &context,
                const QString &msg) {
+  static const bool enableDebugOutput =
+      qEnvironmentVariableIsSet("CZATERIA_DEBUG");
   if (type != QtDebugMsg || enableDebugOutput) {
     defaultHandler(type, context, msg);
   }
@@ -24,7 +25,7 @@ int main(int argc, char **argv) {
                                    "%{file}:%{line} %{function} "
 #endif
                                    "%{message}"));
-  qInstallMessageHandler(msgOutput);
+  defaultHandler = qInstallMessageHandler(msgOutput);
   QCoreApplication::setOrganizationName(QLatin1String("xavery"));
   QCoreApplication::setOrganizationDomain(QLatin1String("github.com"));
   QCoreApplication::setApplicationName(QLatin1String("czateria"));

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -10,6 +10,7 @@
 
 #include <QCloseEvent>
 #include <QCompleter>
+#include <QDebug>
 #include <QMessageBox>
 #include <QRegExpValidator>
 #include <QSettings>


### PR DESCRIPTION
The XP build crashes before entering main, which appears to be caused by
calling qInstallMessageHandler too early. Also, MSVC complains about a few
missing QDebug includes.