### PR TITLE
Unobtrusive private conversation notifications

### DIFF
--- a/.github/workflows/ccpp_win.yml
+++ b/.github/workflows/ccpp_win.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
       
     - name: Install Qt
       uses: jurplel/install-qt-action@v2

--- a/.github/workflows/ccpp_winxp.yml
+++ b/.github/workflows/ccpp_winxp.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
 
     - name: Build for Windows XP
       shell: cmd

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "WinToast"]
+	path = WinToast
+	url = https://github.com/xavery/WinToast.git

--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -396,7 +396,7 @@ bool ChatSession::handlePrivateMessage(const QJsonObject &json) {
     // incoming message
     auto msg = Message::privMessage(json);
     auto it = mCurrentPrivate.find(user);
-    if (it == std::end(mCurrentPrivate)) {
+    if (it == std::end(mCurrentPrivate) || *it == ConversationState::Closed) {
       mCurrentPrivate[user] = ConversationState::InviteReceived;
       mPendingPrivateMsgs[user].push_back(msg);
       emit newPrivateConversation(user);

--- a/ui/appsettings.h
+++ b/ui/appsettings.h
@@ -13,7 +13,9 @@ namespace Czateria {
 struct Room;
 }
 
-struct AppSettings : public Czateria::RoomListModel::LoginDataProvider {
+struct AppSettings : public QObject,
+                     public Czateria::RoomListModel::LoginDataProvider {
+  Q_OBJECT
 private:
   QSettings mSettings;
 
@@ -37,6 +39,10 @@ public:
 
   Setting<bool> useEmojiIcons;
   Setting<bool> savePicturesAutomatically;
+  enum class NotificationStyle { MessageBox, Native };
+  Q_ENUM(NotificationStyle)
+  NotificationStyle notificationStyle = NotificationStyle::MessageBox;
+
   QHash<QString, QVariant> logins;
   QMultiHash<Czateria::RoomListModel::LoginData, int> autologinHash() const;
 

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -45,9 +45,12 @@ class ChatWindowTabWidget::PrivateChatTab : public QStackedWidget {
           QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal);
       connect(buttons, &QDialogButtonBox::accepted, [=]() {
         emit chatWindow->privateConversationAccepted(nickname);
+        this->deleteLater(); // remove self in order to have StackedWidget
+                             // switch to TextEdit
       });
       connect(buttons, &QDialogButtonBox::rejected, [=]() {
         emit chatWindow->privateConversationRejected(nickname);
+        // TODO delete the parent StackedWidget to remove it from the TabWidget
       });
       layout->addWidget(buttons);
       setLayout(layout);
@@ -106,7 +109,7 @@ void ChatWindowTabWidget::openPrivateMessageTab(const QString &nickname) {
   setCurrentWidget(privateMessageTab(nickname));
 }
 
-QPlainTextEdit *
+ChatWindowTabWidget::PrivateChatTab *
 ChatWindowTabWidget::privateMessageTab(const QString &nickname) {
   auto it = mPrivateTabs.find(nickname);
   if (it == std::end(mPrivateTabs)) {
@@ -114,7 +117,7 @@ ChatWindowTabWidget::privateMessageTab(const QString &nickname) {
     it = mPrivateTabs.insert(nickname, widget);
     addTab(widget, nickname);
   }
-  return static_cast<QPlainTextEdit *>(it.value()->currentWidget());
+  return it.value();
 }
 
 int ChatWindowTabWidget::countUnreadPrivateTabs() const {

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -137,6 +137,11 @@ void ChatWindowTabWidget::askAcceptPrivateMessage(const QString &nickname) {
   addTab(widget, nickname);
 }
 
+void ChatWindowTabWidget::addMessageToPrivateChat(const QString &nickname,
+                                                  const QString &str) {
+  privateMessageTab(nickname)->appendPlainText(str);
+}
+
 void ChatWindowTabWidget::indicateTabActivity(int idx, const QIcon &icon) {
   if (idx == currentIndex()) {
     return;

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -213,7 +213,12 @@ void ChatWindowTabWidget::onPrivateConversationStateChanged(
     Q_ASSERT(false);
     break;
   }
-  writePrivateInfo(nickname, message, icon);
+  auto it = mPrivateTabs.find(nickname);
+  if (it != std::end(mPrivateTabs)) {
+    auto tab = it.value();
+    writePrivateInfo(tab, message, icon);
+    tab->removePendingAcceptWidget();
+  }
 }
 
 QString ChatWindowTabWidget::getCurrentNickname() const {
@@ -247,16 +252,12 @@ void ChatWindowTabWidget::onTabCloseRequested(int index) {
   emit privateConversationClosed(nickname);
 }
 
-void ChatWindowTabWidget::writePrivateInfo(const QString &nickname,
+void ChatWindowTabWidget::writePrivateInfo(PrivateChatTab *tab,
                                            const QString &message,
                                            const QIcon &icon) {
-  auto it = mPrivateTabs.find(nickname);
-  if (it == std::end(mPrivateTabs)) {
-    return;
-  }
-  it.value()->appendPlainText(
+  tab->appendPlainText(
       QString(QLatin1String("[%1] %2"))
           .arg(QDateTime::currentDateTime().toString(QLatin1String("HH:mm:ss")))
           .arg(message));
-  indicateTabActivity(it.value(), icon);
+  indicateTabActivity(tab, icon);
 }

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -53,7 +53,7 @@ public:
                         const QString &nickname) {
       auto layout = new QVBoxLayout;
       layout->addWidget(
-          new QLabel(tr("<b>%1</b> wants to talk in private.\nDo you accept?")
+          new QLabel(tr("<b>%1</b> wants to talk in private.<br>Do you accept?")
                          .arg(nickname)));
       auto buttons = new QDialogButtonBox(
           QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal);

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -3,11 +3,11 @@
 #include <QApplication>
 #include <QDebug>
 #include <QDialogButtonBox>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QPlainTextEdit>
 #include <QStackedWidget>
 #include <QTabBar>
+#include <QVBoxLayout>
 
 #include <czatlib/message.h>
 
@@ -37,7 +37,7 @@ class ChatWindowTabWidget::PrivateChatTab : public QStackedWidget {
   struct PendingAcceptWidget : public QWidget {
     PendingAcceptWidget(ChatWindowTabWidget *chatWindow,
                         const QString &nickname) {
-      auto layout = new QHBoxLayout;
+      auto layout = new QVBoxLayout;
       layout->addWidget(
           new QLabel(tr("<b>%1</b> wants to talk in private.\nDo you accept?")
                          .arg(nickname)));

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -53,12 +53,12 @@ class ChatWindowTabWidget::PrivateChatTab : public QStackedWidget {
                          .arg(nickname)));
       auto buttons = new QDialogButtonBox(
           QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal);
-      connect(buttons, &QDialogButtonBox::accepted, [=]() {
+      connect(buttons, &QDialogButtonBox::accepted, this, [=]() {
         emit chatWindow->privateConversationAccepted(nickname);
         this->deleteLater(); // remove self in order to have StackedWidget
                              // switch to TextEdit
       });
-      connect(buttons, &QDialogButtonBox::rejected, [=]() {
+      connect(buttons, &QDialogButtonBox::rejected, this, [=]() {
         emit chatWindow->privateConversationRejected(nickname);
         chatTab->onConversationRejected();
       });

--- a/ui/chatwindowtabwidget.h
+++ b/ui/chatwindowtabwidget.h
@@ -14,8 +14,6 @@ class QPlainTextEdit;
 
 class ChatWindowTabWidget : public QTabWidget {
   Q_OBJECT
-  class PrivateChatTab;
-
 public:
   ChatWindowTabWidget(QWidget *parent = nullptr);
 
@@ -28,9 +26,9 @@ public:
 
   void addMessageToCurrent(const Czateria::Message &msg);
   void addMessageToCurrent(const QString &str);
-  PrivateChatTab *privateMessageTab(const QString &nickname);
   int countUnreadPrivateTabs() const;
   void askAcceptPrivateMessage(const QString &nickname);
+  void addMessageToPrivateChat(const QString &nickname, const QString &str);
 
 signals:
   void privateConversationAccepted(const QString &nickname);
@@ -44,6 +42,9 @@ private:
   void indicateTabActivity(int idx, const QIcon &icon);
   void indicateTabActivity(QWidget *tab, const QIcon &icon);
   void updateTabActivity(int idx);
+
+  class PrivateChatTab;
+  PrivateChatTab *privateMessageTab(const QString &nickname);
 
   QPlainTextEdit *const mMainChatTab;
   QHash<QString, PrivateChatTab *> mPrivateTabs;

--- a/ui/chatwindowtabwidget.h
+++ b/ui/chatwindowtabwidget.h
@@ -28,8 +28,11 @@ public:
   void addMessageToCurrent(const QString &str);
   QPlainTextEdit *privateMessageTab(const QString &nickname);
   int countUnreadPrivateTabs() const;
+  void askAcceptPrivateMessage(const QString &nickname);
 
 signals:
+  void privateConversationAccepted(const QString &nickname);
+  void privateConversationRejected(const QString &nickname);
   void privateConversationClosed(const QString &nickname);
 
 private:
@@ -37,10 +40,12 @@ private:
   void writePrivateInfo(const QString &nickname, const QString &message,
                         const QIcon &icon);
   void indicateTabActivity(int idx, const QIcon &icon);
-  void indicateTabActivity(QPlainTextEdit *tab, const QIcon &icon);
+  void indicateTabActivity(QWidget *tab, const QIcon &icon);
   void updateTabActivity(int idx);
 
-  QHash<QString, QPlainTextEdit *> mPrivateTabs;
+  QPlainTextEdit *const mMainChatTab;
+  class PrivateChatTab;
+  QHash<QString, PrivateChatTab *> mPrivateTabs;
 };
 
 #endif // CHATWINDOWTABWIDGET_H

--- a/ui/chatwindowtabwidget.h
+++ b/ui/chatwindowtabwidget.h
@@ -29,6 +29,9 @@ public:
   int countUnreadPrivateTabs() const;
   void askAcceptPrivateMessage(const QString &nickname);
   void addMessageToPrivateChat(const QString &nickname, const QString &str);
+  bool privTabIsOpen(const QString &nickname) const {
+    return mPrivateTabs.contains(nickname);
+  }
 
 signals:
   void privateConversationAccepted(const QString &nickname);
@@ -37,13 +40,13 @@ signals:
 
 private:
   void onTabCloseRequested(int index);
-  void writePrivateInfo(const QString &nickname, const QString &message,
-                        const QIcon &icon);
   void indicateTabActivity(int idx, const QIcon &icon);
   void indicateTabActivity(QWidget *tab, const QIcon &icon);
   void updateTabActivity(int idx);
 
   class PrivateChatTab;
+  void writePrivateInfo(PrivateChatTab *, const QString &message,
+                        const QIcon &icon);
   PrivateChatTab *privateMessageTab(const QString &nickname);
 
   QPlainTextEdit *const mMainChatTab;

--- a/ui/chatwindowtabwidget.h
+++ b/ui/chatwindowtabwidget.h
@@ -14,6 +14,8 @@ class QPlainTextEdit;
 
 class ChatWindowTabWidget : public QTabWidget {
   Q_OBJECT
+  class PrivateChatTab;
+
 public:
   ChatWindowTabWidget(QWidget *parent = nullptr);
 
@@ -26,7 +28,7 @@ public:
 
   void addMessageToCurrent(const Czateria::Message &msg);
   void addMessageToCurrent(const QString &str);
-  QPlainTextEdit *privateMessageTab(const QString &nickname);
+  PrivateChatTab *privateMessageTab(const QString &nickname);
   int countUnreadPrivateTabs() const;
   void askAcceptPrivateMessage(const QString &nickname);
 
@@ -44,7 +46,6 @@ private:
   void updateTabActivity(int idx);
 
   QPlainTextEdit *const mMainChatTab;
-  class PrivateChatTab;
   QHash<QString, PrivateChatTab *> mPrivateTabs;
 };
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -313,7 +313,13 @@ MainChatWindow::~MainChatWindow() { delete ui; }
 
 void MainChatWindow::onPrivateConvNotificationAccepted(
     const QString &nickname) {
+  // todo switch focus to tab & remove the yes/no dialog from stackedwidget
   doAcceptPrivateConversation(nickname);
+}
+
+void MainChatWindow::onPrivateConvNotificationRejected(
+    const QString &nickname) {
+  mChatSession->rejectPrivateConversation(nickname);
 }
 
 void MainChatWindow::onNewPrivateConversation(const QString &nickname) {
@@ -322,7 +328,7 @@ void MainChatWindow::onNewPrivateConversation(const QString &nickname) {
     doAcceptPrivateConversation(nickname);
   } else {
     ui->tabWidget->askAcceptPrivateMessage(nickname);
-    mMainWindow->displayNotification(this, nickname);
+    mMainWindow->displayNotification(this, nickname, mChatSession->channel());
   }
 }
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -307,13 +307,18 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
 
 MainChatWindow::~MainChatWindow() { delete ui; }
 
+void MainChatWindow::onPrivateConvNotificationAccepted(
+    const QString &nickname) {
+  doAcceptPrivateConversation(nickname);
+}
+
 void MainChatWindow::onNewPrivateConversation(const QString &nickname) {
   if (mAutoAcceptPrivs->isChecked()) {
     ui->tabWidget->openPrivateMessageTab(nickname);
     doAcceptPrivateConversation(nickname);
   } else {
     ui->tabWidget->askAcceptPrivateMessage(nickname);
-    mMainWindow->displayNotification();
+    mMainWindow->displayNotification(this, nickname);
   }
 }
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -284,10 +284,10 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
   });
   connect(mChatSession, &Czateria::ChatSession::imageDelivered, this,
           [=](auto &&nick) {
-            ui->tabWidget->privateMessageTab(nick)->appendPlainText(
-                tr("[%1] Image delivered")
-                    .arg(QDateTime::currentDateTime().toString(
-                        QLatin1String("HH:mm:ss"))));
+            ui->tabWidget->addMessageToPrivateChat(
+                nick, tr("[%1] Image delivered")
+                          .arg(QDateTime::currentDateTime().toString(
+                              QLatin1String("HH:mm:ss"))));
           });
 
   connect(ui->lineEdit, &QLineEdit::returnPressed, this,

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -302,11 +302,14 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
   connect(ui->tabWidget, &QTabWidget::currentChanged, this,
           [=](auto idx) { mSendImageAction->setEnabled(idx != 0); });
   connect(ui->tabWidget, &ChatWindowTabWidget::privateConversationAccepted,
-          this,
-          [=](auto &&nickname) { doAcceptPrivateConversation(nickname); });
+          this, [=](auto &&nickname) {
+            doAcceptPrivateConversation(nickname);
+            mainWin->removeNotification(this, nickname);
+          });
   connect(ui->tabWidget, &ChatWindowTabWidget::privateConversationRejected,
           this, [=](auto &&nickname) {
             mChatSession->rejectPrivateConversation(nickname);
+            mainWin->removeNotification(this, nickname);
           });
 
   ui->lineEdit->installEventFilter(this);

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -313,7 +313,7 @@ MainChatWindow::~MainChatWindow() { delete ui; }
 
 void MainChatWindow::onPrivateConvNotificationAccepted(
     const QString &nickname) {
-  // todo switch focus to tab & remove the yes/no dialog from stackedwidget
+  ui->tabWidget->openPrivateMessageTab(nickname);
   doAcceptPrivateConversation(nickname);
 }
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -430,11 +430,7 @@ bool MainChatWindow::sendImageFromMime(const QMimeData *mime) {
 }
 
 void MainChatWindow::closePrivateConvMsgbox(const QString &nickname) {
-  if (auto msgbox = mPendingPrivRequests.value(nickname, nullptr)) {
-    msgbox->reject();
-    msgbox->deleteLater();
-    mPendingPrivRequests.remove(nickname);
-  }
+  mMainWindow->removeNotification(this, nickname);
 }
 
 void MainChatWindow::dragEnterEvent(QDragEnterEvent *ev) {

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -130,7 +130,7 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
                                Czateria::AvatarHandler &avatars,
                                const Czateria::Room &room,
                                const AppSettings &settings, MainWindow *mainWin)
-    : QMainWindow(nullptr), ui(new Ui::ChatWidget),
+    : QMainWindow(nullptr), ui(new Ui::ChatWidget), mMainWindow(mainWin),
       mChatSession(new Czateria::ChatSession(login, avatars, room, this)),
       mSortProxy(new QSortFilterProxyModel(this)),
       mNicknameCompleter(
@@ -159,7 +159,7 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
   mShowChannelListAction->setToolTip(tr("Show channel list"));
   mShowChannelListAction->setStatusTip(tr("Shows the channel list window"));
   connect(mShowChannelListAction, &QAction::triggered,
-          [=](auto) { mainWin->show(); });
+          [=](auto) { mMainWindow->show(); });
   toolbar->addAction(mShowChannelListAction);
 
   connect(mSendImageAction, &QAction::triggered, [=](auto) {
@@ -313,6 +313,7 @@ void MainChatWindow::onNewPrivateConversation(const QString &nickname) {
     doAcceptPrivateConversation(nickname);
   } else {
     ui->tabWidget->askAcceptPrivateMessage(nickname);
+    mMainWindow->displayNotification();
   }
 }
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -302,9 +302,10 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
   connect(ui->tabWidget, &QTabWidget::currentChanged, this,
           [=](auto idx) { mSendImageAction->setEnabled(idx != 0); });
   connect(ui->tabWidget, &ChatWindowTabWidget::privateConversationAccepted,
+          this,
           [=](auto &&nickname) { doAcceptPrivateConversation(nickname); });
   connect(ui->tabWidget, &ChatWindowTabWidget::privateConversationRejected,
-          [=](auto &&nickname) {
+          this, [=](auto &&nickname) {
             mChatSession->rejectPrivateConversation(nickname);
           });
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -236,22 +236,21 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
           ui->nicknameLabel, &QLabel::setText);
   connect(mChatSession, &Czateria::ChatSession::imageReceived,
           [=](auto &&nickname, auto &&image) {
-            auto textedit = ui->tabWidget->privateMessageTab(nickname);
             if (mAppSettings.savePicturesAutomatically) {
               auto defaultPath =
                   imageDefaultPath(mChatSession->channel(), nickname);
               image.save(defaultPath);
-              textedit->appendPlainText(
-                  tr("[%1] Image saved as %2")
-                      .arg(QDateTime::currentDateTime().toString(
-                          QLatin1String("HH:mm:ss")))
-                      .arg(defaultPath));
+              ui->tabWidget->addMessageToPrivateChat(
+                  nickname, tr("[%1] Image saved as %2")
+                                .arg(QDateTime::currentDateTime().toString(
+                                    QLatin1String("HH:mm:ss")))
+                                .arg(defaultPath));
             } else {
               showImageDialog(this, nickname, mChatSession->channel(), image);
-              textedit->appendPlainText(
-                  tr("[%1] Image received")
-                      .arg(QDateTime::currentDateTime().toString(
-                          QLatin1String("HH:mm:ss"))));
+              ui->tabWidget->addMessageToPrivateChat(
+                  nickname, tr("[%1] Image received")
+                                .arg(QDateTime::currentDateTime().toString(
+                                    QLatin1String("HH:mm:ss"))));
             }
             notifyActivity();
           });

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -328,7 +328,7 @@ void MainChatWindow::onPrivateConvNotificationRejected(
 }
 
 void MainChatWindow::onNewPrivateConversation(const QString &nickname) {
-  if (mAutoAcceptPrivs->isChecked()) {
+  if (mAutoAcceptPrivs->isChecked() || ui->tabWidget->privTabIsOpen(nickname)) {
     ui->tabWidget->openPrivateMessageTab(nickname);
     doAcceptPrivateConversation(nickname);
   } else {

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -33,6 +33,8 @@ public:
                           const AppSettings &settings, MainWindow *mainWin);
   ~MainChatWindow();
 
+  void onPrivateConvNotificationAccepted(const QString &nickname);
+
 private:
   void onNewPrivateConversation(const QString &nickname);
   void onReturnPressed();

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -35,6 +35,7 @@ public:
   ~MainChatWindow();
 
   void onPrivateConvNotificationAccepted(const QString &nickname);
+  void onPrivateConvNotificationRejected(const QString &nickname);
 
 private:
   void onNewPrivateConversation(const QString &nickname);

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -43,6 +43,7 @@ private:
   void updateWindowTitle();
 
   Ui::ChatWidget *ui;
+  MainWindow *const mMainWindow;
   Czateria::ChatSession *const mChatSession;
   QSortFilterProxyModel *const mSortProxy;
   QCompleter *const mNicknameCompleter;

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -65,7 +65,6 @@ private:
   QAction *const mSendImageAction;
   QAction *const mShowChannelListAction;
   QAction *const mUseEmoji;
-  QHash<QString, QMessageBox *> mPendingPrivRequests;
 };
 
 #endif // MAINCHATWINDOW_H

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -238,10 +238,23 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
 
   startTimer(channelListRefreshInterval);
 
+  connect(ui->actionMessage_box, &QAction::toggled, this, [&](bool checked) {
+    if (checked) {
+      mNotifications = NotificationSupport::msgBox();
+    }
+  });
+  connect(ui->actionNative, &QAction::toggled, this, [&](bool checked) {
+    if (checked) {
+      mNotifications = NotificationSupport::native();
+    }
+  });
+
   auto grp = new QActionGroup(this);
   grp->addAction(ui->actionNative);
   grp->addAction(ui->actionMessage_box);
   ui->actionMessage_box->setChecked(true);
+  auto native = NotificationSupport::native();
+  ui->actionNative->setEnabled(native && native->supported());
 }
 
 void MainWindow::onChannelDoubleClicked(const QModelIndex &idx) {
@@ -372,8 +385,9 @@ void MainWindow::createChatWindow(
   win->show();
 }
 
-void MainWindow::removeNotification(MainChatWindow *, const QString &) {
-  // FIXME
+void MainWindow::removeNotification(MainChatWindow *chatWin,
+                                    const QString &nickname) {
+  mNotifications->removeNotification(chatWin, nickname);
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *ev) {
@@ -391,9 +405,10 @@ void MainWindow::timerEvent(QTimerEvent *) { refreshRoomList(); }
 
 MainWindow::~MainWindow() { delete ui; }
 
-void MainWindow::displayNotification(MainChatWindow *, const QString &,
-                                     const QString &) {
-  // FIXME
+void MainWindow::displayNotification(MainChatWindow *chatWin,
+                                     const QString &nickname,
+                                     const QString &channel) {
+  mNotifications->displayNotification(chatWin, nickname, channel);
 }
 
 void MainWindow::closeEvent(QCloseEvent *ev) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -262,6 +262,10 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
   ui->actionNative->setChecked(native_supported &&
                                mAppSettings.notificationStyle ==
                                    AppSettings::NotificationStyle::Native);
+  if (!native_supported) {
+    ui->actionNative->setStatusTip(
+        tr("Desktop notifications not supported or disabled system-wide"));
+  }
   ui->actionMessage_box->setChecked(
       !native_supported || mAppSettings.notificationStyle ==
                                AppSettings::NotificationStyle::MessageBox);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -366,8 +366,7 @@ void MainWindow::createChatWindow(
   win->show();
 }
 
-void MainWindow::removeNotification(MainChatWindow *chatWin,
-                                    const QString &nickname) {
+void MainWindow::removeNotification(MainChatWindow *, const QString &) {
   // FIXME
 }
 
@@ -386,9 +385,8 @@ void MainWindow::timerEvent(QTimerEvent *) { refreshRoomList(); }
 
 MainWindow::~MainWindow() { delete ui; }
 
-void MainWindow::displayNotification(MainChatWindow *chatWin,
-                                     const QString &nickname,
-                                     const QString &channel) {
+void MainWindow::displayNotification(MainChatWindow *, const QString &,
+                                     const QString &) {
   // FIXME
 }
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -262,8 +262,9 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
   ui->actionNative->setChecked(native_supported &&
                                mAppSettings.notificationStyle ==
                                    AppSettings::NotificationStyle::Native);
-  ui->actionMessage_box->setChecked(mAppSettings.notificationStyle ==
-                                    AppSettings::NotificationStyle::MessageBox);
+  ui->actionMessage_box->setChecked(
+      !native_supported || mAppSettings.notificationStyle ==
+                               AppSettings::NotificationStyle::MessageBox);
 }
 
 void MainWindow::onChannelDoubleClicked(const QModelIndex &idx) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -262,10 +262,6 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
   ui->actionNative->setChecked(native_supported &&
                                mAppSettings.notificationStyle ==
                                    AppSettings::NotificationStyle::Native);
-  if (!native_supported) {
-    ui->actionNative->setStatusTip(
-        tr("Desktop notifications not supported or disabled system-wide"));
-  }
   ui->actionMessage_box->setChecked(
       !native_supported || mAppSettings.notificationStyle ==
                                AppSettings::NotificationStyle::MessageBox);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -241,20 +241,29 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
   connect(ui->actionMessage_box, &QAction::toggled, this, [&](bool checked) {
     if (checked) {
       mNotifications = NotificationSupport::msgBox();
+      mAppSettings.notificationStyle =
+          AppSettings::NotificationStyle::MessageBox;
     }
   });
   connect(ui->actionNative, &QAction::toggled, this, [&](bool checked) {
     if (checked) {
       mNotifications = NotificationSupport::native();
+      mAppSettings.notificationStyle = AppSettings::NotificationStyle::Native;
     }
   });
 
   auto grp = new QActionGroup(this);
   grp->addAction(ui->actionNative);
   grp->addAction(ui->actionMessage_box);
-  ui->actionMessage_box->setChecked(true);
+
   auto native = NotificationSupport::native();
-  ui->actionNative->setEnabled(native && native->supported());
+  const bool native_supported = native && native->supported();
+  ui->actionNative->setEnabled(native_supported);
+  ui->actionNative->setChecked(native_supported &&
+                               mAppSettings.notificationStyle ==
+                                   AppSettings::NotificationStyle::Native);
+  ui->actionMessage_box->setChecked(mAppSettings.notificationStyle ==
+                                    AppSettings::NotificationStyle::MessageBox);
 }
 
 void MainWindow::onChannelDoubleClicked(const QModelIndex &idx) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -18,7 +18,7 @@
 #include <QSharedPointer>
 #include <QSortFilterProxyModel>
 
-#ifndef QT_NO_DBUS
+#ifdef QT_DBUS_LIB
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusReply>
@@ -244,7 +244,7 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
 
   startTimer(channelListRefreshInterval);
 
-#ifndef QT_NO_DBUS
+#ifdef QT_DBUS_LIB
   auto bus = QDBusConnection::sessionBus();
   if (bus.isConnected()) {
     bus.connect(dbusServiceName, dbusPath, dbusInterfaceName,
@@ -411,7 +411,7 @@ MainWindow::~MainWindow() { delete ui; }
 
 void MainWindow::displayNotification(MainChatWindow *chatWin,
                                      const QString &nickname) {
-#ifndef QT_NO_DBUS
+#ifdef QT_DBUS_LIB
   auto bus = QDBusConnection::sessionBus();
 
   if (bus.isConnected()) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -10,6 +10,7 @@
 #include <czatlib/loginsession.h>
 #include <czatlib/roomlistmodel.h>
 
+#include <QActionGroup>
 #include <QCloseEvent>
 #include <QCompleter>
 #include <QDebug>
@@ -236,6 +237,11 @@ MainWindow::MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
           [=](bool checked) { mAppSettings.useEmojiIcons = checked; });
 
   startTimer(channelListRefreshInterval);
+
+  auto grp = new QActionGroup(this);
+  grp->addAction(ui->actionNative);
+  grp->addAction(ui->actionMessage_box);
+  ui->actionMessage_box->setChecked(true);
 }
 
 void MainWindow::onChannelDoubleClicked(const QModelIndex &idx) {

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -9,6 +9,8 @@
 #include <czatlib/avatarhandler.h>
 #include <czatlib/loginfailreason.h>
 
+#include "notificationsupport.h"
+
 class QNetworkAccessManager;
 class QNetworkReply;
 class CaptchaDialog;
@@ -50,6 +52,7 @@ private:
   AppSettings &mAppSettings;
   QList<MainChatWindow *> mChatWindows;
   QHash<QString, QWeakPointer<Czateria::LoginSession>> mCurrentSessions;
+  std::unique_ptr<NotificationSupport> mNotifications;
 
   void onChannelDoubleClicked(const QModelIndex &);
   void onChannelClicked(const QModelIndex &);

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -65,6 +65,8 @@ private:
   void saveLoginData(const QString &, const QString &);
   void createChatWindow(QSharedPointer<Czateria::LoginSession>,
                         const Czateria::Room &);
+  void onChatWindowDestroyed(QObject *);
+  void removeNotification(quint32);
 
   class AutologinState;
   friend class AutologinState;
@@ -74,6 +76,7 @@ private:
 
 private slots:
   void onNotificationActionInvoked(quint32, QString);
+  void onNotificationClosed(quint32, quint32);
 };
 
 #endif // MAINWINDOW_H

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -33,7 +33,7 @@ public:
   explicit MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
                       QWidget *parent = nullptr);
   ~MainWindow() override;
-  void displayNotification();
+  void displayNotification(MainChatWindow *chatWin, const QString &nickname);
 
 protected:
   void closeEvent(QCloseEvent *ev) override;
@@ -48,6 +48,13 @@ private:
   AppSettings &mAppSettings;
   QList<MainChatWindow *> mChatWindows;
   QHash<QString, QWeakPointer<Czateria::LoginSession>> mCurrentSessions;
+
+  struct NotificationContext {
+    MainChatWindow *chatWin;
+    QString nickname;
+  };
+
+  QHash<quint32, NotificationContext> mLiveNotifications;
 
   void onChannelDoubleClicked(const QModelIndex &);
   void onChannelClicked(const QModelIndex &);

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -33,6 +33,7 @@ public:
   explicit MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
                       QWidget *parent = nullptr);
   ~MainWindow() override;
+  void displayNotification();
 
 protected:
   void closeEvent(QCloseEvent *ev) override;
@@ -63,6 +64,9 @@ private:
 
   bool eventFilter(QObject *, QEvent *) override;
   void timerEvent(QTimerEvent *) override;
+
+private slots:
+  void onNotificationActionInvoked(quint32, QString);
 };
 
 #endif // MAINWINDOW_H

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -51,13 +51,6 @@ private:
   QList<MainChatWindow *> mChatWindows;
   QHash<QString, QWeakPointer<Czateria::LoginSession>> mCurrentSessions;
 
-  struct NotificationContext {
-    MainChatWindow *chatWin;
-    QString nickname;
-  };
-
-  QHash<quint32, NotificationContext> mLiveNotifications;
-
   void onChannelDoubleClicked(const QModelIndex &);
   void onChannelClicked(const QModelIndex &);
   bool isLoginDataEntered();
@@ -67,19 +60,12 @@ private:
   void saveLoginData(const QString &, const QString &);
   void createChatWindow(QSharedPointer<Czateria::LoginSession>,
                         const Czateria::Room &);
-  void onChatWindowDestroyed(QObject *);
-  void removeNotification(quint32);
-  template <typename F> void removeNotifications(F &&);
 
   class AutologinState;
   friend class AutologinState;
 
   bool eventFilter(QObject *, QEvent *) override;
   void timerEvent(QTimerEvent *) override;
-
-private slots:
-  void onNotificationActionInvoked(quint32, QString);
-  void onNotificationClosed(quint32, quint32);
 };
 
 #endif // MAINWINDOW_H

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -33,7 +33,8 @@ public:
   explicit MainWindow(QNetworkAccessManager *nam, AppSettings &settings,
                       QWidget *parent = nullptr);
   ~MainWindow() override;
-  void displayNotification(MainChatWindow *chatWin, const QString &nickname);
+  void displayNotification(MainChatWindow *chatWin, const QString &nickname,
+                           const QString &channel);
 
 protected:
   void closeEvent(QCloseEvent *ev) override;

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -35,6 +35,7 @@ public:
   ~MainWindow() override;
   void displayNotification(MainChatWindow *chatWin, const QString &nickname,
                            const QString &channel);
+  void removeNotification(MainChatWindow *chatWin, const QString &nickname);
 
 protected:
   void closeEvent(QCloseEvent *ev) override;
@@ -68,6 +69,7 @@ private:
                         const Czateria::Room &);
   void onChatWindowDestroyed(QObject *);
   void removeNotification(quint32);
+  template <typename F> void removeNotifications(F &&);
 
   class AutologinState;
   friend class AutologinState;

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -139,15 +139,23 @@
      <x>0</x>
      <y>0</y>
      <width>491</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuOptions">
     <property name="title">
      <string>Options</string>
     </property>
+    <widget class="QMenu" name="menuNotification_style">
+     <property name="title">
+      <string>Notification style</string>
+     </property>
+     <addaction name="actionMessage_box"/>
+     <addaction name="actionNative"/>
+    </widget>
     <addaction name="actionSave_pictures_automatically"/>
     <addaction name="actionUse_emoji_icons"/>
+    <addaction name="menuNotification_style"/>
    </widget>
    <addaction name="menuOptions"/>
   </widget>
@@ -186,6 +194,28 @@
    </property>
    <property name="statusTip">
     <string>Convert icons and emoticons to emoji</string>
+   </property>
+  </action>
+  <action name="actionMessage_box">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Message box</string>
+   </property>
+   <property name="statusTip">
+    <string>New private conversation notifications will be displayed in a message box</string>
+   </property>
+  </action>
+  <action name="actionNative">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Native</string>
+   </property>
+   <property name="statusTip">
+    <string>The platform's desktop notification mechanism will be used for notifying about new private conversations</string>
    </property>
   </action>
  </widget>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -204,7 +204,7 @@
     <string>Message box</string>
    </property>
    <property name="statusTip">
-    <string>New private conversation notifications will be displayed in a message box</string>
+    <string>Use a message box to notify about new private conversations</string>
    </property>
   </action>
   <action name="actionNative">
@@ -218,7 +218,7 @@
     <string>Native</string>
    </property>
    <property name="statusTip">
-    <string>The platform's desktop notification mechanism will be used for notifying about new private conversations</string>
+    <string>Use desktop notifications for new private conversations</string>
    </property>
   </action>
  </widget>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -211,6 +211,9 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Native</string>
    </property>

--- a/ui/notificationsupport.cpp
+++ b/ui/notificationsupport.cpp
@@ -8,12 +8,12 @@ std::unique_ptr<NotificationSupport> NotificationSupport::msgBox() {
 #ifdef QT_DBUS_LIB
 #include "notificationsupport_dbus.h"
 std::unique_ptr<NotificationSupport> NotificationSupport::native() {
-  return std::make_unique<NotificationSupportDBus>();
+  return std::unique_ptr<NotificationSupport>(new NotificationSupportDBus);
 }
 #elif defined(Q_OS_WIN)
 #include "notificationsupport_win10.h"
 std::unique_ptr<NotificationSupport> NotificationSupport::native() {
-  return std::make_unique<NotificationSupportWin10>();
+  return std::unique_ptr<NotificationSupport>(new NotificationSupportWin10);
 }
 #else
 std::unique_ptr<NotificationSupport> NotificationSupport::native() {

--- a/ui/notificationsupport.cpp
+++ b/ui/notificationsupport.cpp
@@ -1,0 +1,22 @@
+#include "notificationsupport.h"
+#include "notificationsupport_msgbox.h"
+
+std::unique_ptr<NotificationSupport> NotificationSupport::msgBox() {
+  return std::make_unique<NotificationSupportMsgBox>();
+}
+
+#ifdef QT_DBUS_LIB
+#include "notificationsupport_dbus.h"
+std::unique_ptr<NotificationSupport> NotificationSupport::native() {
+  return std::make_unique<NotificationSupportDBus>();
+}
+#elif defined(Q_OS_WIN)
+#include "notificationsupport_win10.h"
+std::unique_ptr<NotificationSupport> NotificationSupport::native() {
+  return std::make_unique<NotificationSupportWin10>();
+}
+#else
+std::unique_ptr<NotificationSupport> NotificationSupport::native() {
+  return nullptr;
+}
+#endif

--- a/ui/notificationsupport.h
+++ b/ui/notificationsupport.h
@@ -14,6 +14,7 @@ public:
                                    const QString &channel) = 0;
   virtual void removeNotification(MainChatWindow *chatWin,
                                   const QString &nickname) = 0;
+  virtual bool supported() const = 0;
 
   static std::unique_ptr<NotificationSupport> msgBox();
   static std::unique_ptr<NotificationSupport> native();

--- a/ui/notificationsupport.h
+++ b/ui/notificationsupport.h
@@ -1,0 +1,21 @@
+#ifndef NOTIFICATIONSUPPORT_H
+#define NOTIFICATIONSUPPORT_H
+
+class MainChatWindow;
+class QString;
+
+#include <memory>
+
+struct NotificationSupport {
+public:
+  virtual void displayNotification(MainChatWindow *chatWin,
+                                   const QString &nickname,
+                                   const QString &channel) = 0;
+  virtual void removeNotification(MainChatWindow *chatWin,
+                                  const QString &nickname) = 0;
+
+  static std::unique_ptr<NotificationSupport> msgBox();
+  static std::unique_ptr<NotificationSupport> native();
+};
+
+#endif // NOTIFICATIONSUPPORT_H

--- a/ui/notificationsupport.h
+++ b/ui/notificationsupport.h
@@ -8,6 +8,7 @@ class QString;
 
 struct NotificationSupport {
 public:
+  virtual ~NotificationSupport() = default;
   virtual void displayNotification(MainChatWindow *chatWin,
                                    const QString &nickname,
                                    const QString &channel) = 0;

--- a/ui/notificationsupport_dbus.cpp
+++ b/ui/notificationsupport_dbus.cpp
@@ -1,0 +1,109 @@
+#include "notificationsupport_dbus.h"
+
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusReply>
+#include <QDebug>
+
+#include "mainchatwindow.h"
+
+namespace {
+const QLatin1String dbusServiceName("org.freedesktop.Notifications");
+const QLatin1String dbusInterfaceName("org.freedesktop.Notifications");
+const QLatin1String dbusPath("/org/freedesktop/Notifications");
+const QLatin1String acceptPrivConvAction("accept_priv_conv");
+const QLatin1String rejectPrivConvAction("reject_priv_conv");
+} // namespace
+
+NotificationSupportDBus::NotificationSupportDBus()
+    : mSessionBus(QDBusConnection::sessionBus()) {
+  if (mSessionBus.isConnected()) {
+    mSessionBus.connect(dbusServiceName, dbusPath, dbusInterfaceName,
+                        QLatin1String("ActionInvoked"), this,
+                        SLOT(onNotificationActionInvoked(quint32, QString)));
+    mSessionBus.connect(dbusServiceName, dbusPath, dbusInterfaceName,
+                        QLatin1String("NotificationClosed"), this,
+                        SLOT(onNotificationClosed(quint32, quint32)));
+  }
+}
+
+void NotificationSupportDBus::displayNotification(MainChatWindow *chatWin,
+                                                  const QString &nickname,
+                                                  const QString &channel) {
+  auto m = QDBusMessage::createMethodCall(
+      dbusServiceName, dbusPath, dbusInterfaceName, QLatin1String("Notify"));
+  QVariantList args;
+  args.append(QCoreApplication::applicationName());
+  args.append(0U);
+  args.append(QString());
+  args.append(tr("Incoming private conversation"));
+  args.append(QString(QLatin1String("<b>%1</b> in room <b>%2</b> wants to "
+                                    "start a conversation."))
+                  .arg(nickname)
+                  .arg(channel));
+  args.append(QStringList() << acceptPrivConvAction << tr("Accept")
+                            << rejectPrivConvAction << tr("Reject"));
+  args.append(QMap<QString, QVariant>{
+      std::make_pair(QLatin1String("category"), QLatin1String("im.received"))});
+  args.append(static_cast<int32_t>(-1));
+  m.setArguments(args);
+  QDBusReply<quint32> replyMsg = mSessionBus.call(m);
+  if (replyMsg.isValid() && replyMsg.value() > 0) {
+    mLiveNotifications.insert(replyMsg.value(),
+                              NotificationContext{chatWin, nickname});
+    connect(chatWin, &QObject::destroyed, this,
+            &NotificationSupportDBus::onChatWindowDestroyed,
+            Qt::UniqueConnection);
+  }
+}
+
+void NotificationSupportDBus::removeNotification(MainChatWindow *chatWin,
+                                                 const QString &nickname) {
+  removeNotifications([&](auto &&ctx) {
+    return ctx.chatWin == chatWin && ctx.nickname == nickname;
+  });
+}
+
+void NotificationSupportDBus::onChatWindowDestroyed(QObject *obj) {
+  removeNotifications([&](auto &&ctx) { return ctx.chatWin == obj; });
+}
+
+void NotificationSupportDBus::removeNotification(quint32 notificationId) {
+  auto m = QDBusMessage::createMethodCall(dbusServiceName, dbusPath,
+                                          dbusInterfaceName,
+                                          QLatin1String("CloseNotification"));
+  QVariantList args;
+  args.append(notificationId);
+  m.setArguments(args);
+  mSessionBus.call(m);
+}
+
+void NotificationSupportDBus::onNotificationActionInvoked(
+    quint32 notificationId, QString action) {
+  auto it = mLiveNotifications.find(notificationId);
+  if (it == std::end(mLiveNotifications)) {
+    return;
+  }
+  qDebug() << notificationId << action;
+  auto &context = it.value();
+  if (action == acceptPrivConvAction) {
+    context.chatWin->onPrivateConvNotificationAccepted(context.nickname);
+  } else if (action == rejectPrivConvAction) {
+    context.chatWin->onPrivateConvNotificationRejected(context.nickname);
+  }
+}
+
+void NotificationSupportDBus::onNotificationClosed(quint32 id, quint32) {
+  mLiveNotifications.remove(id);
+  qDebug() << id;
+}
+
+template <typename F> void NotificationSupportDBus::removeNotifications(F &&f) {
+  const auto it_end = std::end(mLiveNotifications);
+  for (auto it = std::begin(mLiveNotifications); it != it_end; ++it) {
+    if (f(it.value())) {
+      removeNotification(it.key());
+    }
+  }
+}

--- a/ui/notificationsupport_dbus.cpp
+++ b/ui/notificationsupport_dbus.cpp
@@ -31,6 +31,7 @@ NotificationSupportDBus::NotificationSupportDBus()
 void NotificationSupportDBus::displayNotification(MainChatWindow *chatWin,
                                                   const QString &nickname,
                                                   const QString &channel) {
+  Q_ASSERT(mSessionBus.isConnected());
   auto m = QDBusMessage::createMethodCall(
       dbusServiceName, dbusPath, dbusInterfaceName, QLatin1String("Notify"));
   QVariantList args;
@@ -65,11 +66,16 @@ void NotificationSupportDBus::removeNotification(MainChatWindow *chatWin,
   });
 }
 
+bool NotificationSupportDBus::supported() const {
+  return mSessionBus.isConnected();
+}
+
 void NotificationSupportDBus::onChatWindowDestroyed(QObject *obj) {
   removeNotifications([&](auto &&ctx) { return ctx.chatWin == obj; });
 }
 
 void NotificationSupportDBus::removeNotification(quint32 notificationId) {
+  Q_ASSERT(mSessionBus.isConnected());
   auto m = QDBusMessage::createMethodCall(dbusServiceName, dbusPath,
                                           dbusInterfaceName,
                                           QLatin1String("CloseNotification"));

--- a/ui/notificationsupport_dbus.h
+++ b/ui/notificationsupport_dbus.h
@@ -7,7 +7,7 @@
 #include <QHash>
 #include <QObject>
 
-class NotificationSupportDBus : public QObject, NotificationSupport {
+class NotificationSupportDBus : public QObject, public NotificationSupport {
   Q_OBJECT
 public:
   NotificationSupportDBus();

--- a/ui/notificationsupport_dbus.h
+++ b/ui/notificationsupport_dbus.h
@@ -15,6 +15,7 @@ public:
                            const QString &channel) override;
   void removeNotification(MainChatWindow *chatWin,
                           const QString &nickname) override;
+  bool supported() const override;
 
 private:
   void onChatWindowDestroyed(QObject *);

--- a/ui/notificationsupport_dbus.h
+++ b/ui/notificationsupport_dbus.h
@@ -1,0 +1,36 @@
+#ifndef NOTIFICATIONSUPPORTDBUS_H
+#define NOTIFICATIONSUPPORTDBUS_H
+
+#include "notificationsupport.h"
+
+#include <QDBusConnection>
+#include <QHash>
+#include <QObject>
+
+class NotificationSupportDBus : public QObject, NotificationSupport {
+  Q_OBJECT
+public:
+  NotificationSupportDBus();
+  void displayNotification(MainChatWindow *chatWin, const QString &nickname,
+                           const QString &channel) override;
+  void removeNotification(MainChatWindow *chatWin,
+                          const QString &nickname) override;
+
+private:
+  void onChatWindowDestroyed(QObject *);
+  void removeNotification(quint32);
+  template <typename F> void removeNotifications(F &&);
+
+  QDBusConnection mSessionBus;
+  struct NotificationContext {
+    MainChatWindow *chatWin;
+    QString nickname;
+  };
+  QHash<quint32, NotificationContext> mLiveNotifications;
+
+private slots:
+  void onNotificationActionInvoked(quint32, QString);
+  void onNotificationClosed(quint32, quint32);
+};
+
+#endif // NOTIFICATIONSUPPORTDBUS_H

--- a/ui/notificationsupport_dbus.h
+++ b/ui/notificationsupport_dbus.h
@@ -18,6 +18,7 @@ public:
   bool supported() const override;
 
 private:
+  bool isServicePresent() const;
   void onChatWindowDestroyed(QObject *);
   void removeNotification(quint32);
   template <typename F> void removeNotifications(F &&);

--- a/ui/notificationsupport_msgbox.cpp
+++ b/ui/notificationsupport_msgbox.cpp
@@ -1,0 +1,40 @@
+#include "notificationsupport_msgbox.h"
+
+#include <QAbstractButton>
+#include <QMessageBox>
+
+#include "mainchatwindow.h"
+
+void NotificationSupportMsgBox::displayNotification(MainChatWindow *chatWin,
+                                                    const QString &nickname,
+                                                    const QString &) {
+  auto question =
+      MainChatWindow::tr("%1 wants to talk in private.\nDo you accept?")
+          .arg(nickname);
+  auto msgbox = new QMessageBox(
+      QMessageBox::Question, MainChatWindow::tr("New private conversation"),
+      question, QMessageBox::Yes | QMessageBox::No, chatWin);
+  mPendingPrivRequests[nickname] = msgbox;
+  msgbox->setDefaultButton(QMessageBox::Yes);
+  msgbox->button(QMessageBox::Yes)->setShortcut(QKeySequence());
+  msgbox->button(QMessageBox::No)->setShortcut(QKeySequence());
+  QObject::connect(msgbox, &QDialog::finished, chatWin, [=](int result) {
+    if (result == QMessageBox::Yes) {
+      chatWin->onPrivateConvNotificationAccepted(nickname);
+    } else {
+      chatWin->onPrivateConvNotificationRejected(nickname);
+    }
+  });
+  msgbox->show();
+  msgbox->raise();
+  msgbox->activateWindow();
+}
+
+void NotificationSupportMsgBox::removeNotification(MainChatWindow *,
+                                                   const QString &nickname) {
+  if (auto msgbox = mPendingPrivRequests.value(nickname, nullptr)) {
+    msgbox->reject();
+    msgbox->deleteLater();
+    mPendingPrivRequests.remove(nickname);
+  }
+}

--- a/ui/notificationsupport_msgbox.h
+++ b/ui/notificationsupport_msgbox.h
@@ -12,6 +12,7 @@ struct NotificationSupportMsgBox : public NotificationSupport {
                            const QString &channel) override;
   void removeNotification(MainChatWindow *chatWin,
                           const QString &nickname) override;
+  bool supported() const override { return true; }
 
 private:
   QHash<QString, QMessageBox *> mPendingPrivRequests;

--- a/ui/notificationsupport_msgbox.h
+++ b/ui/notificationsupport_msgbox.h
@@ -1,0 +1,20 @@
+#ifndef NOTIFICATIONSUPPORTMSGBOX_H
+#define NOTIFICATIONSUPPORTMSGBOX_H
+
+#include "notificationsupport.h"
+
+#include <QHash>
+
+class QMessageBox;
+
+struct NotificationSupportMsgBox : public NotificationSupport {
+  void displayNotification(MainChatWindow *chatWin, const QString &nickname,
+                           const QString &channel) override;
+  void removeNotification(MainChatWindow *chatWin,
+                          const QString &nickname) override;
+
+private:
+  QHash<QString, QMessageBox *> mPendingPrivRequests;
+};
+
+#endif // NOTIFICATIONSUPPORTMSGBOX_H

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -63,9 +63,9 @@ void NotificationSupportWin10::displayNotification(MainChatWindow *chatWin,
   if (toastId >= 0) {
     mLiveNotifications.insert(toastId, NotificationContext{chatWin, nickname});
     handler->mToastId = toastId;
-    /*QObject::connect(chatWin, &QObject::destroyed, this,
-                     &NotificationSupportWin10::onChatWindowDestroyed,
-                     Qt::UniqueConnection);*/
+    connect(chatWin, &QObject::destroyed, this,
+            &NotificationSupportWin10::onChatWindowDestroyed,
+            Qt::UniqueConnection);
   }
 }
 

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -1,12 +1,103 @@
 #include "notificationsupport_win10.h"
 
-NotificationSupportWin10::NotificationSupportWin10() {}
+#include "mainchatwindow.h"
 
-void NotificationSupportWin10::displayNotification(MainChatWindow *,
-                                                   const QString &,
-                                                   const QString &) {}
+#include <WinToast/src/wintoastlib.h>
 
-void NotificationSupportWin10::removeNotification(MainChatWindow *,
-                                                  const QString &) {}
+#include <QCoreApplication>
 
-bool NotificationSupportWin10::supported() const { return false; }
+using namespace WinToastLib;
+
+class NotificationSupportWin10::ToastHandler : public IWinToastHandler {
+public:
+  ToastHandler(NotificationSupportWin10 &parent, MainChatWindow *chatWin,
+               const QString &nickname)
+      : mParent(parent), mChatWin(chatWin), mNickname(nickname) {}
+  INT64 mToastId = -1;
+
+private:
+  void toastActivated() const override {}
+  void toastActivated(int actionIndex) const override {
+    if (actionIndex == 0) {
+      QMetaObject::invokeMethod(mChatWin, [=]() {
+        mChatWin->onPrivateConvNotificationAccepted(mNickname);
+      });
+    } else if (actionIndex == 1) {
+      QMetaObject::invokeMethod(mChatWin, [=]() {
+        mChatWin->onPrivateConvNotificationRejected(mNickname);
+      });
+    }
+  }
+  void toastDismissed(WinToastDismissalReason) const override {
+    mParent.mLiveNotifications.remove(mToastId);
+  }
+  void toastFailed() const override {
+    mParent.mLiveNotifications.remove(mToastId);
+  }
+
+  NotificationSupportWin10 &mParent;
+  MainChatWindow *const mChatWin;
+  const QString &mNickname;
+};
+
+NotificationSupportWin10::NotificationSupportWin10()
+    : mWinToast(*WinToast::instance()) {
+  auto appname = QCoreApplication::applicationName().toStdWString();
+  mWinToast.setAppName(appname);
+  mWinToast.setAppUserModelId(WinToast::configureAUMI(
+      QCoreApplication::organizationName().toStdWString(), appname));
+}
+
+void NotificationSupportWin10::displayNotification(MainChatWindow *chatWin,
+                                                   const QString &nickname,
+                                                   const QString &channel) {
+  auto templ = WinToastTemplate{WinToastTemplate::Text02};
+  templ.setFirstLine(
+      MainChatWindow::tr("Incoming private conversation").toStdWString());
+  templ.setSecondLine(
+      QString(QLatin1String("%1 in room %2 wants to start a conversation"))
+          .arg(nickname)
+          .arg(channel)
+          .toStdWString());
+  templ.addAction(MainChatWindow::tr("Accept").toStdWString());
+  templ.addAction(MainChatWindow::tr("Reject").toStdWString());
+  auto handler = std::make_shared<NotificationSupportWin10::ToastHandler>(
+      *this, chatWin, nickname);
+  auto toastId = mWinToast.showToast(templ, handler);
+  if (toastId >= 0) {
+    mLiveNotifications.insert(toastId, NotificationContext{chatWin, nickname});
+    handler->mToastId = toastId;
+    /*QObject::connect(chatWin, &QObject::destroyed, this,
+                     &NotificationSupportWin10::onChatWindowDestroyed,
+                     Qt::UniqueConnection);*/
+  }
+}
+
+void NotificationSupportWin10::removeNotification(MainChatWindow *chatWin,
+                                                  const QString &nickname) {
+  removeNotifications([&](auto &&ctx) {
+    return ctx.chatWin == chatWin && ctx.nickname == nickname;
+  });
+}
+
+bool NotificationSupportWin10::supported() const {
+  return mWinToast.initialize() && WinToast::isSupportingModernFeatures();
+}
+
+void NotificationSupportWin10::onChatWindowDestroyed(QObject *obj) {
+  removeNotifications([&](auto &&ctx) { return ctx.chatWin == obj; });
+}
+
+void NotificationSupportWin10::removeNotification(qint64 id) {
+  mWinToast.hideToast(id);
+}
+
+template <typename F>
+void NotificationSupportWin10::removeNotifications(F &&f) {
+  const auto it_end = std::end(mLiveNotifications);
+  for (auto it = std::begin(mLiveNotifications); it != it_end; ++it) {
+    if (f(it.value())) {
+      removeNotification(it.key());
+    }
+  }
+}

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -8,3 +8,5 @@ void NotificationSupportWin10::displayNotification(MainChatWindow *,
 
 void NotificationSupportWin10::removeNotification(MainChatWindow *,
                                                   const QString &) {}
+
+bool NotificationSupportWin10::supported() const { return false; }

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -1,0 +1,3 @@
+#include "notificationsupport_win10.h"
+
+NotificationSupportWin10::NotificationSupportWin10() {}

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -1,3 +1,10 @@
 #include "notificationsupport_win10.h"
 
 NotificationSupportWin10::NotificationSupportWin10() {}
+
+void NotificationSupportWin10::displayNotification(MainChatWindow *,
+                                                   const QString &,
+                                                   const QString &) {}
+
+void NotificationSupportWin10::removeNotification(MainChatWindow *,
+                                                  const QString &) {}

--- a/ui/notificationsupport_win10.cpp
+++ b/ui/notificationsupport_win10.cpp
@@ -19,13 +19,9 @@ private:
   void toastActivated() const override {}
   void toastActivated(int actionIndex) const override {
     if (actionIndex == 0) {
-      QMetaObject::invokeMethod(mChatWin, [=]() {
-        mChatWin->onPrivateConvNotificationAccepted(mNickname);
-      });
+      mChatWin->onPrivateConvNotificationAccepted(mNickname);
     } else if (actionIndex == 1) {
-      QMetaObject::invokeMethod(mChatWin, [=]() {
-        mChatWin->onPrivateConvNotificationRejected(mNickname);
-      });
+      mChatWin->onPrivateConvNotificationRejected(mNickname);
     }
   }
   void toastDismissed(WinToastDismissalReason) const override {
@@ -37,7 +33,7 @@ private:
 
   NotificationSupportWin10 &mParent;
   MainChatWindow *const mChatWin;
-  const QString &mNickname;
+  const QString mNickname;
 };
 
 NotificationSupportWin10::NotificationSupportWin10()

--- a/ui/notificationsupport_win10.h
+++ b/ui/notificationsupport_win10.h
@@ -6,6 +6,11 @@
 class NotificationSupportWin10 : public NotificationSupport {
 public:
   NotificationSupportWin10();
+
+  void displayNotification(MainChatWindow *chatWin, const QString &nickname,
+                           const QString &channel) override;
+  void removeNotification(MainChatWindow *chatWin,
+                          const QString &nickname) override;
 };
 
 #endif // NOTIFICATIONSUPPORTWIN10_H

--- a/ui/notificationsupport_win10.h
+++ b/ui/notificationsupport_win10.h
@@ -11,6 +11,7 @@ public:
                            const QString &channel) override;
   void removeNotification(MainChatWindow *chatWin,
                           const QString &nickname) override;
+  bool supported() const override;
 };
 
 #endif // NOTIFICATIONSUPPORTWIN10_H

--- a/ui/notificationsupport_win10.h
+++ b/ui/notificationsupport_win10.h
@@ -4,15 +4,15 @@
 #include "notificationsupport.h"
 
 #include <QHash>
+#include <QObject>
 #include <QString>
-
-class QObject;
 
 namespace WinToastLib {
 class WinToast;
 }
 
-class NotificationSupportWin10 : public NotificationSupport {
+class NotificationSupportWin10 : public QObject, public NotificationSupport {
+  Q_OBJECT
 public:
   NotificationSupportWin10();
 

--- a/ui/notificationsupport_win10.h
+++ b/ui/notificationsupport_win10.h
@@ -1,0 +1,11 @@
+#ifndef NOTIFICATIONSUPPORTWIN10_H
+#define NOTIFICATIONSUPPORTWIN10_H
+
+#include "notificationsupport.h"
+
+class NotificationSupportWin10 : public NotificationSupport {
+public:
+  NotificationSupportWin10();
+};
+
+#endif // NOTIFICATIONSUPPORTWIN10_H

--- a/ui/notificationsupport_win10.h
+++ b/ui/notificationsupport_win10.h
@@ -3,6 +3,15 @@
 
 #include "notificationsupport.h"
 
+#include <QHash>
+#include <QString>
+
+class QObject;
+
+namespace WinToastLib {
+class WinToast;
+}
+
 class NotificationSupportWin10 : public NotificationSupport {
 public:
   NotificationSupportWin10();
@@ -12,6 +21,21 @@ public:
   void removeNotification(MainChatWindow *chatWin,
                           const QString &nickname) override;
   bool supported() const override;
+
+private:
+  class ToastHandler;
+  friend class ToastHandler;
+
+  void onChatWindowDestroyed(QObject *);
+  void removeNotification(qint64);
+  template <typename F> void removeNotifications(F &&);
+
+  WinToastLib::WinToast &mWinToast;
+  struct NotificationContext {
+    MainChatWindow *chatWin;
+    QString nickname;
+  };
+  QHash<qint64, NotificationContext> mLiveNotifications;
 };
 
 #endif // NOTIFICATIONSUPPORTWIN10_H

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -4,42 +4,46 @@ include(../czateria.pri)
 
 QT       += core gui network widgets websockets
 
-unix:qtHaveModule(dbus): QT += dbus
+unix:qtHaveModule(dbus) {
+  QT += dbus
+  SOURCES += notificationsupport_dbus.cpp
+  HEADERS += notificationsupport_dbus.h
+}
+win32 {
+  SOURCES += notificationsupport_win10.cpp
+  HEADERS += notificationsupport_win10.h
+}
 
 INCLUDEPATH += ..
 
 SOURCES += \
-  appsettings.cpp \
+    appsettings.cpp \
     autologindatadialog.cpp \
-        main.cpp \
-        mainwindow.cpp \
+    main.cpp \
+    mainwindow.cpp \
     captchadialog.cpp \
     mainchatwindow.cpp \
     chatwindowtabwidget.cpp \
     notificationsupport.cpp \
-    notificationsupport_dbus.cpp \
     notificationsupport_msgbox.cpp \
-    notificationsupport_win10.cpp \
     userlistview.cpp
 
 HEADERS += \
-  appsettings.h \
+    appsettings.h \
     autologindatadialog.h \
-        mainwindow.h \
+    mainwindow.h \
     captchadialog.h \
     mainchatwindow.h \
     chatwindowtabwidget.h \
     notificationsupport.h \
-    notificationsupport_dbus.h \
     notificationsupport_msgbox.h \
-    notificationsupport_win10.h \
     userlistview.h \
     util.h
 
 FORMS += \
     autologindatadialog.ui \
-  chatwidget.ui \
-        mainwindow.ui \
+    chatwidget.ui \
+    mainwindow.ui \
     captchadialog.ui
 
 win32:CONFIG (release, debug|release): LIBS += -L../czatlib/release -lczatlib
@@ -48,5 +52,4 @@ else:unix: LIBS += -L../czatlib -lczatlib
 
 unix: PRE_TARGETDEPS += ../czatlib/libczatlib.a
 
-RESOURCES += \
-    rsrc.qrc
+RESOURCES += rsrc.qrc

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -16,6 +16,10 @@ SOURCES += \
     captchadialog.cpp \
     mainchatwindow.cpp \
     chatwindowtabwidget.cpp \
+    notificationsupport.cpp \
+    notificationsupport_dbus.cpp \
+    notificationsupport_msgbox.cpp \
+    notificationsupport_win10.cpp \
     userlistview.cpp
 
 HEADERS += \
@@ -25,6 +29,10 @@ HEADERS += \
     captchadialog.h \
     mainchatwindow.h \
     chatwindowtabwidget.h \
+    notificationsupport.h \
+    notificationsupport_dbus.h \
+    notificationsupport_msgbox.h \
+    notificationsupport_win10.h \
     userlistview.h \
     util.h
 

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -12,6 +12,7 @@ unix:qtHaveModule(dbus) {
 win32 {
   SOURCES += notificationsupport_win10.cpp ../WinToast/src/wintoastlib.cpp
   HEADERS += notificationsupport_win10.h ../WinToast/src/wintoastlib.h
+  DEFINES += UNICODE PSAPI_VERSION=1
 }
 
 INCLUDEPATH += ..

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -10,8 +10,8 @@ unix:qtHaveModule(dbus) {
   HEADERS += notificationsupport_dbus.h
 }
 win32 {
-  SOURCES += notificationsupport_win10.cpp
-  HEADERS += notificationsupport_win10.h
+  SOURCES += notificationsupport_win10.cpp ../WinToast/src/wintoastlib.cpp
+  HEADERS += notificationsupport_win10.h ../WinToast/src/wintoastlib.h
 }
 
 INCLUDEPATH += ..

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -4,6 +4,8 @@ include(../czateria.pri)
 
 QT       += core gui network widgets websockets
 
+unix:qtHaveModule(dbus): QT += dbus
+
 INCLUDEPATH += ..
 
 SOURCES += \


### PR DESCRIPTION
Replace the modal message window currently used for asking the user whether the private conversation request should be accepted or rejected with desktop notifications :

![Screenshot_2020-06-08_00-05-52](https://user-images.githubusercontent.com/127875/83981221-3fa24900-a91c-11ea-91d4-cb489a2626de.png)

Additionally - in case desktop notifications aren't supported or the given notification isn't acted upon before timing out - the current functionality of the message box is integrated into the tab window :

![Screenshot_2020-06-08_00-06-05](https://user-images.githubusercontent.com/127875/83981222-429d3980-a91c-11ea-8926-e27c2a1db3a2.png)