### PR TITLE
(Hopefully) fix crash on reconnecting when using sessions created by autologin

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -110,7 +110,9 @@ private:
     auto session = new Czateria::LoginSession(mMainWindow->mNAM);
     auto rooms = mLoginHash.values(*mLoginIter);
 
-    connect(session, &Czateria::LoginSession::loginSuccessful, [=]() {
+    auto conn = QSharedPointer<QMetaObject::Connection>::create();
+    *conn = connect(session, &Czateria::LoginSession::loginSuccessful, [=]() {
+      disconnect(*conn);
       for (auto roomId : rooms) {
         if (auto room = mMainWindow->mRoomListModel->roomFromId(roomId)) {
           mMainWindow->createChatWindow(

--- a/workflow_build_windows.bat
+++ b/workflow_build_windows.bat
@@ -1,6 +1,7 @@
-choco install jom
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 mkdir build
 cd build
+powershell -Command "Invoke-WebRequest http://download.qt.io/official_releases/jom/jom.zip -O jom.zip"
+7z x jom.zip
 qmake ..\czateria.pro -spec win32-msvc
 jom all


### PR DESCRIPTION
Well, this is embarassing.

Even though AutologinState is only created once at creation of MainWindow, the
lambdas connected to the signals of the created sessions outlive the
AutologinState object, which leads to a crash when reconnecting due to
loginSuccessful being fired long after the AutologinState object is destroyed.
The crash occurs because the lambda captures a AutologinState *this in order to
access the mMainWindow member.