### PR TITLE
Reinitialise ChatSession variables in ChatSession::start

### DIFF
--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -209,6 +209,12 @@ ChatSession::~ChatSession() {
 }
 
 void ChatSession::start() {
+  if (mKeepaliveTimerId) {
+    killTimer(mKeepaliveTimerId);
+  }
+  mCurrentPrivate.clear();
+  mPendingPrivateMsgs.clear();
+  mHelloReceived = false;
   mWebSocket->open(QUrl(mHost));
   mKeepaliveTimerId = startTimer(keepaliveInterval);
 }
@@ -463,11 +469,7 @@ void ChatSession::onSocketError(QAbstractSocket::SocketError err) {
   if (err == QAbstractSocket::RemoteHostClosedError) {
     if (mHelloReceived) {
       if (mLoginSession->restart(mRoom)) {
-        mHelloReceived = false;
         qInfo() << "Connection closed by server, trying to reconnect";
-        killTimer(mKeepaliveTimerId);
-        mCurrentPrivate.clear();
-        mPendingPrivateMsgs.clear();
       } else {
         emit sessionExpired();
       }

--- a/czatlib/chatsession.h
+++ b/czatlib/chatsession.h
@@ -83,7 +83,7 @@ private:
   QString mNickname;
   const QString mHost;
   bool mHelloReceived;
-  int mKeepaliveTimerId;
+  int mKeepaliveTimerId = 0;
   QHash<QString, ConversationState> mCurrentPrivate;
   QHash<QString, QVector<Message>> mPendingPrivateMsgs;
   UserListModel *const mUserListModel;


### PR DESCRIPTION
This is needed, because onSocketError is going to be called in only one of these
sessions, and the rest will be restarted because the LoginSession object emitted
the loginSuccessful signal after re-logging. Not doing this caused an assert to
be hit in timerEvent() due to two timers coexisting and mKeepaliveTimerId
pointing to the new timer ID.