### PR TITLE
Don't create new QSharedPointer objects for each ChatWindow

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -113,10 +113,10 @@ private:
     auto conn = QSharedPointer<QMetaObject::Connection>::create();
     *conn = connect(session, &Czateria::LoginSession::loginSuccessful, [=]() {
       disconnect(*conn);
+      auto ses = QSharedPointer<Czateria::LoginSession>(session);
       for (auto roomId : rooms) {
         if (auto room = mMainWindow->mRoomListModel->roomFromId(roomId)) {
-          mMainWindow->createChatWindow(
-              QSharedPointer<Czateria::LoginSession>(session), *room);
+          mMainWindow->createChatWindow(ses, *room);
         }
       }
       nextSession();


### PR DESCRIPTION
Another em-bare-assing mistake. The created QSharedPointer instances had no
relation to one another and LoginSessions ended up being destroyed twice.