### PR TITLE
Fix build with Qt 5.15

### DIFF
--- a/czatlib/roomlistmodel.cpp
+++ b/czatlib/roomlistmodel.cpp
@@ -31,7 +31,11 @@ void RoomListModel::download() {
   connect(mReply, &QNetworkReply::finished, this,
           &RoomListModel::onDownloadFinished);
   void (QNetworkReply::*errSignal)(QNetworkReply::NetworkError) =
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+      &QNetworkReply::errorOccurred;
+#else
       &QNetworkReply::error;
+#endif
   connect(mReply, errSignal, this, &RoomListModel::downloadError);
 }
 


### PR DESCRIPTION
The build fails with Qt 5.15 due to QNetworkReply::error being deprecated in
favour of ::errorOccurred. I'd rather be aware of any API changes in newer
versions than add QT_DISABLE_DEPRECATED_BEFORE=0x050600 to the compiler defines,
since that would potentially filter out too many of them.