### PR TITLE
Disallow multiple inflight room-list requests

### DIFF
--- a/czatlib/roomlistmodel.cpp
+++ b/czatlib/roomlistmodel.cpp
@@ -29,6 +29,10 @@ RoomListModel::RoomListModel(QObject *parent, QNetworkAccessManager *nam,
 }
 
 void RoomListModel::download() {
+  if (mReply) {
+    qInfo() << "Download request already pending";
+    return;
+  }
   mReply = mNAM->get(QNetworkRequest(
       QUrl(QLatin1String("https://czateria.interia.pl/rooms-list"))));
   connect(mReply, &QNetworkReply::finished, this,
@@ -114,6 +118,9 @@ QVector<Room> RoomListModel::jsonToChannels(const QJsonArray &arr) {
 }
 
 void RoomListModel::onDownloadFinished() {
+  if (!mReply) {
+    return;
+  }
   if (mReply->error() != QNetworkReply::NoError) {
     mReply->deleteLater();
     mReply = nullptr;


### PR DESCRIPTION
Fixes #108.

This is more of a shot in the dark : the actual sequence of events that caused
the referenced bug is probably impossible to recreate from the posted stack
trace, as it would require knowing the value of "mReply" during the first and
second call to onDownloadFinished().

The actual reason behind the crash is unknown to me, as I've always operated
under the assumption that finished() is the last signal that's emitted for a
given QNetworkReply, and there will be no more signals for that object after
finished() is emitted. Qt docs confirm this by saying "After this signal is
emitted, there will be no more updates to the reply's data or metadata."

However, this apparently wasn't the case here, as onDownloadFinished() was most
definitely called twice, once from the application's event loop, and for a
second time from QDialog's own internal event loop. My hypothesis is that a
second invocation of onDownloadFinished() has been queued in the background
while the dialog was displayed. The QDialog loop picked it up, but mReply at the
time must have already been null because the dialog had been created as a reply
to the jsonError signal, which is emitted after onDownloadFinished() sets mReply
to null.

In the worst case, this fixes a memory leak which could occurr if download()
were to be called for a second time before onDownloadFinished() is called :
in such a scenario, the QNetworkReply object created by the first call to
download() would be lost.