### PR TITLE
Create separate line edits for each conversation tab

### DIFF
--- a/ui/chatwidget.ui
+++ b/ui/chatwidget.ui
@@ -148,7 +148,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="lineEdit"/>
+       <widget class="QStackedWidget" name="stackedLineEdits"/>
       </item>
      </layout>
     </widget>

--- a/ui/chatwindowtabwidget.cpp
+++ b/ui/chatwindowtabwidget.cpp
@@ -260,7 +260,7 @@ void ChatWindowTabWidget::onTabCloseRequested(int index) {
   removeTab(index);
   delete w;
   mPrivateTabs.remove(nickname);
-  emit privateConversationClosed(nickname);
+  emit privateConversationClosed(nickname, index);
 }
 
 void ChatWindowTabWidget::writePrivateInfo(PrivateChatTab *tab,

--- a/ui/chatwindowtabwidget.h
+++ b/ui/chatwindowtabwidget.h
@@ -41,7 +41,7 @@ public:
 signals:
   void privateConversationAccepted(const QString &nickname);
   void privateConversationRejected(const QString &nickname);
-  void privateConversationClosed(const QString &nickname);
+  void privateConversationClosed(const QString &nickname, int tabIndex);
 
 private:
   void onTabCloseRequested(int index);

--- a/ui/mainchatwindow.h
+++ b/ui/mainchatwindow.h
@@ -11,6 +11,7 @@ class QMessageBox;
 struct AppSettings;
 class MainWindow;
 class QMimeData;
+class QLineEdit;
 
 namespace Ui {
 class ChatWidget;
@@ -54,6 +55,8 @@ private:
   bool sendImageFromMime(const QMimeData *);
   void onUserLeft(const QString &);
   void onPrivateConversationCancelled(const QString &);
+  QLineEdit *createLineEdit();
+  QLineEdit *currentLineEdit() const;
 
   void dragEnterEvent(QDragEnterEvent *) override;
   void dropEvent(QDropEvent *) override;


### PR DESCRIPTION
This makes it harder to accidentally send a message to someone when you're writing one and a new automatically-approved private message request comes in, opening a new tab.

Besides, it just makes sense : you can have other stuff stored as a "draft" for each of your interlocutors.