### PR TITLE
Modify the code to be compatible with Qt 6

### DIFF
--- a/czatlib/avatarhandler.h
+++ b/czatlib/avatarhandler.h
@@ -90,7 +90,12 @@ public:
     auto request = QNetworkRequest(QUrl(address));
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                          QNetworkRequest::PreferCache);
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#else
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+#endif
     auto reply = mNAM->get(request);
     QObject::connect(reply, &QNetworkReply::finished, [=]() {
       if (reply->error() == QNetworkReply::NoError) {

--- a/czatlib/icons.cpp
+++ b/czatlib/icons.cpp
@@ -66,8 +66,7 @@ namespace Czateria {
 QString convertRawMessage(const QString &str, IconReplaceMode replaceMode) {
   const auto member = replaceMode == IconReplaceMode::Text ? &Icon::text : &Icon::emoji;
   static const auto re =
-      QRegularExpression(QLatin1String("<icon>(\\d+)</icon>"),
-                         QRegularExpression::OptimizeOnFirstUsageOption);
+      QRegularExpression(QLatin1String("<icon>(\\d+)</icon>"));
   auto rv = str;
   auto it = re.globalMatch(str);
   int offset = 0;

--- a/ui/appsettings.cpp
+++ b/ui/appsettings.cpp
@@ -16,7 +16,7 @@ QVector<QRegularExpression> fromVariantList(const QList<QVariant> &varList) {
   QVector<QRegularExpression> rv;
   rv.reserve(varList.size());
   for (auto &&var : varList) {
-    if (var.type() == QVariant::RegularExpression) {
+    if (var.canConvert<QRegularExpression>()) {
       auto rgx = var.toRegularExpression();
       if (rgx.isValid()) {
         rv.push_back(rgx);
@@ -29,7 +29,7 @@ QVector<QRegularExpression> fromVariantList(const QList<QVariant> &varList) {
 void readRegexList(const QSettings &settings, const QLatin1String &key,
                    QVector<QRegularExpression> &dest) {
   auto variant = settings.value(key);
-  if (variant.isValid() && variant.type() == QVariant::List) {
+  if (variant.isValid() && variant.canConvert<QVariantList>()) {
     dest = fromVariantList(variant.toList());
   }
 }
@@ -59,7 +59,7 @@ AppSettings::AppSettings()
                   QLatin1String("%~/.czateria/logs/%u/%Y-%M-%D/%c/%p.log")) {
 
   auto variant = mSettings.value(QLatin1String("logins"));
-  if (variant.isValid() && variant.type() == QVariant::Hash) {
+  if (variant.isValid() && variant.canConvert<QVariantHash>()) {
     auto loginsHash = variant.toHash();
     for (auto it = loginsHash.cbegin(); it != loginsHash.cend(); ++it) {
       logins[it.key()] = it.value().toString();
@@ -67,7 +67,7 @@ AppSettings::AppSettings()
   }
 
   variant = mSettings.value(QLatin1String("notifications"));
-  if (variant.isValid() && variant.type() == QVariant::String) {
+  if (variant.isValid() && variant.canConvert<QString>()) {
     auto styleStr = variant.toString();
     bool ok = false;
     auto metaEnum = QMetaEnum::fromType<AppSettings::NotificationStyle>();

--- a/ui/filebasedlogger.cpp
+++ b/ui/filebasedlogger.cpp
@@ -55,14 +55,13 @@ QString makeLogPath(const QString &input, const QRegularExpression &rgx,
     auto m = it.next();
     auto matchStart = m.capturedStart();
     if (inpos != m.capturedStart()) {
-      out.append(QStringRef(&input, inpos, matchStart - inpos));
+      out.append(input.constData() + inpos, matchStart - inpos);
     }
-    out.append(
-        replaceToken(m.capturedRef().at(1), date, session, unknownTokenFn));
+    out.append(replaceToken(m.captured().at(1), date, session, unknownTokenFn));
     inpos = m.capturedEnd();
   }
   if (inpos != input.length()) {
-    out.append(QStringRef(&input, inpos, input.length() - inpos));
+    out.append(input.constData() + inpos, input.length() - inpos);
   }
   return out;
 }
@@ -79,20 +78,20 @@ static const QRegularExpression privTokensRgx(QLatin1String("%[" COMMON_TOKENS
 
 QFileInfo makeRoomLogPath(const QString &path,
                           const Czateria::ChatSession *session) {
-  return makeLogPath(path, roomTokensRgx, session,
-                     [](auto) { return QString(); });
+  return QFileInfo{makeLogPath(path, roomTokensRgx, session,
+                               [](auto) { return QString(); })};
 }
 
 QFileInfo makePrivLogPath(const QString &path,
                           const Czateria::ChatSession *session,
                           const Czateria::Message &msg) {
-  return makeLogPath(path, privTokensRgx, session, [&](auto t) {
+  return QFileInfo{makeLogPath(path, privTokensRgx, session, [&](auto t) {
     if (t.unicode() == 'p') {
       return sanitize(msg.nickname());
     } else {
       return QString();
     }
-  });
+  })};
 }
 } // namespace
 

--- a/ui/mainchatwindow.cpp
+++ b/ui/mainchatwindow.cpp
@@ -273,8 +273,14 @@ MainChatWindow::MainChatWindow(QSharedPointer<Czateria::LoginSession> login,
   mSortProxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
   mSortProxy->setSortLocaleAware(true);
   mSortProxy->setDynamicSortFilter(true);
+
   void (QSortFilterProxyModel::*setFilterFn)(const QString &) =
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
       &QSortFilterProxyModel::setFilterRegExp;
+#else
+      &QSortFilterProxyModel::setFilterRegularExpression;
+#endif
+
   connect(ui->lineEdit_2, &QLineEdit::textChanged, mSortProxy, setFilterFn);
 
   ui->listView->setModel(mSortProxy);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -16,7 +16,7 @@
 #include <QCompleter>
 #include <QDebug>
 #include <QMessageBox>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <QSettings>
 #include <QSharedPointer>
 #include <QSortFilterProxyModel>
@@ -85,7 +85,8 @@ void loginErrorMessageBox(QWidget *parent, Ui::MainWindow *ui,
 // this should really be placed somewhere in czatlib, but QValidator lives
 // inside Qt's gui module that we don't want czatlib to depend on.
 const QValidator *getNicknameValidator() {
-  static const QRegExpValidator validator(QRegExp(QLatin1String("[^'@\\$]+")));
+  static const QRegularExpressionValidator validator(
+      QRegularExpression(QLatin1String("[^'@\\$]+")));
   return &validator;
 }
 


### PR DESCRIPTION
Changes needed in order to make the project compilable with Qt 6, seeing how the
recently branched 6.2 includes the crucial websockets module.

I still want to keep compatibility with 5.6 due to XP support, so some of the
changes aren't as trivial as they could've been - here's a summary of the less
obvious ones :

* QNetworkRequest::RedirectPolicyAttribute is used in place of
  QNetworkRequest::FollowRedirectsAttribute, which was kind-of deprecated in
  Qt 5.9 and removed in Qt 6. Behaviour is supposed to be the same, according to
  the documentation.
* QRegularExpression::OptimizeOnFirstUsageOption seems to have been removed
  altogether, and its usage wasn't dictated by any benchmarking anyway, so it
  was just removed. If I recall correctly, sufficiently new Qt versions do the
  optimisation automagically anyway.
* QVariant::type() was deprecated, but its functionality in the context that's
  used here can be replaced with canConvert(), which is more lenient than
  QVariant::type() anyway, so this shouldn't cause issues when trying to read
  settings files written by earlier versions of the program.
* QStringRef usages were replaced with equivalent constructs based on raw
  pointers. Unfortunately, QStringRef has been replaced with QStringView in Qt6,
  while QStringView itself was introduced in Qt 5.10, leaving the pointer
  solution as the lowest common denominator of the two.