### PR TITLE
Don't execute a runtime version check if compiling with Qt 5.8+

### DIFF
--- a/czatlib/chatsession.cpp
+++ b/czatlib/chatsession.cpp
@@ -119,6 +119,7 @@ QJsonObject sessionEndMsg() { return czateriaCodeMsg(80); }
 QJsonObject keepaliveMsg() { return czateriaCodeMsg(1003); }
 
 bool shouldUseQueuedConnectionForWebSocket() {
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
   // QTBUG-55506
   static QVariant cached_result;
   if (cached_result.isValid()) {
@@ -142,6 +143,9 @@ bool shouldUseQueuedConnectionForWebSocket() {
   }
   cached_result = rv;
   return rv;
+#else
+  return false;
+#endif
 }
 
 bool privSubcodeToState(int subcode, Czateria::ConversationState &state) {


### PR DESCRIPTION
If compiling with Qt 5.8 or newer, the application won't run with older versions
anyway, therefore the check can just be completely skipped. It must remain when
compiling with pre-5.8 headers though, as it is possible that the application
might run with newer ones at runtime.