### PR TITLE
Store any outgoing messages until the conversation is accepted

### DIFF
--- a/czatlib/chatsession.h
+++ b/czatlib/chatsession.h
@@ -109,7 +109,8 @@ private:
 
   struct PrivConvContext {
     ConversationState mState;
-    QVector<Message> mPendingMessages;
+    QVector<Message> mPendingIncomingMessages;
+    QVector<Message> mPendingOutgoingMessages;
   };
   using PrivConvHash = QHash<QString, PrivConvContext>;
   PrivConvHash mCurrentPrivate;


### PR DESCRIPTION
The server seems to discard any messages sent by us if our partner has not yet accepted the conversation. To prevent losing messages, save them until the conversation is accepted and send them when that happens.